### PR TITLE
SEO keyword optimization across service pages

### DIFF
--- a/src/lib/data/blogPosts.ts
+++ b/src/lib/data/blogPosts.ts
@@ -27,7 +27,7 @@ export const blogPosts: BlogPost[] = [
 				At its simplest, equity management is everything a company does to operate its stock and equity compensation programs. It spans strategy and design (what to grant and to whom), day-to-day operations (processing grants, vesting, exercises, and releases), compliance and reporting (tax, securities, and accounting obligations), and the participant experience (helping employees understand and act on their awards).
 			</p>
 			<p>
-				People sometimes use "equity management," "stock plan administration," and "equity compensation" interchangeably, but they aren't quite the same thing. Equity compensation refers to the awards themselves; the options, units, and shares a company grants. <a href="/services/equity-plan-administration">Stock plan administration</a> is the operational work of running those programs. Equity management is the broader umbrella that includes both the strategic and the operational sides of the discipline.
+				People sometimes use "equity management," "stock plan administration," and "equity compensation" interchangeably, but they aren't quite the same thing. Equity compensation refers to the awards themselves: the options, units, and shares a company grants. <a href="/services/equity-plan-administration">Stock plan administration</a> is the operational work of running those programs. Equity management is the broader umbrella that includes both the strategic and the operational sides of the discipline.
 			</p>
 
 			<h2>The Main Types of Equity-Based Compensation</h2>
@@ -77,12 +77,12 @@ export const blogPosts: BlogPost[] = [
 
 			<h3>Compliance and Reporting</h3>
 			<p>
-				Equity compensation is heavily regulated. Companies must navigate Section 16 reporting for insiders, ASC 718 expense calculations, Section 6039 information returns for ISOs and ESPPs, 409A valuations for private companies, and a range of securities and international tax requirements. Missing a filing or miscalculating an expense can carry real consequences.
+				Equity compensation is heavily regulated. Companies must navigate Section 16 reporting for insiders, ASC 718 expense calculations, Section 6039 information returns for ISOs and ESPPs, 409A valuations for private companies, and a range of securities and international tax requirements. Missing a filing or miscalculating an expense can mean IRS penalties, restated financials, or eroded employee trust.
 			</p>
 
 			<h3>System and Vendor Management</h3>
 			<p>
-				Most companies run their programs on a dedicated equity platform such as Carta, Shareworks, Fidelity, or Equity Edge Online. Selecting, implementing, and optimizing these systems, and integrating them with HRIS and payroll, is a discipline in itself. <a href="/services/vendor-support">Vendor support and implementation</a> ensures your technology actually delivers on its promise.
+				Most companies run their programs on a dedicated equity platform such as Carta, Shareworks, Fidelity, or Equity Edge Online. Selecting, implementing, and optimizing these systems, and integrating them with HRIS and payroll, is a discipline in itself. <a href="/services/vendor-support">Vendor support and implementation</a> ensures your technology delivers on its promise.
 			</p>
 
 			<h3>Strategic Transactions</h3>
@@ -92,7 +92,7 @@ export const blogPosts: BlogPost[] = [
 
 			<h2>In-House vs. an Equity Management Company</h2>
 			<p>
-				As programs grow, most companies reach a point where managing equity internally becomes a strain. The person responsible often wears several hats; juggling HR, payroll, or finance alongside equity, and the "team of one" model starts to crack under increasing volume and complexity.
+				As programs grow, most companies reach a point where managing equity internally becomes a strain. The person responsible often wears several hats, juggling HR, payroll, or finance alongside equity. As volume and complexity climb, the "team of one" model starts to crack.
 			</p>
 			<p>
 				That's where an equity management company comes in. Rather than building and maintaining a full in-house team, you partner with specialists who live and breathe equity compensation. A good partner can take complete ownership of your program, augment your existing team, or step in for specific projects and peak periods.

--- a/src/lib/data/blogPosts.ts
+++ b/src/lib/data/blogPosts.ts
@@ -19,7 +19,7 @@ export const blogPosts: BlogPost[] = [
 		readingTime: 11,
 		content: `
 			<p class="lead">
-				Equity management is the discipline of administering a company's equity-based compensation across its entire lifecycle, from designing a plan and issuing grants to tracking vesting, ensuring compliance, and supporting employees. Done well, it turns equity into a powerful tool for attracting and retaining talent. Done poorly, it creates compliance risk, accounting headaches, and frustrated employees. This guide explains what equity management involves, the main types of equity-based compensation, and how to decide whether to manage it in-house or partner with an equity management company.
+				Equity management is the discipline of administering a company’s equity-based compensation across its entire lifecycle, from designing a plan and issuing grants to tracking vesting, ensuring compliance, and supporting employees. Done well, it turns equity into a powerful tool for attracting and retaining talent. Done poorly, it creates compliance risk, accounting headaches, and frustrated employees. This guide explains what equity management involves, the main types of equity-based compensation, and how to decide whether to manage it in-house or partner with an equity management company.
 			</p>
 
 			<h2>What Is Equity Management?</h2>
@@ -27,12 +27,12 @@ export const blogPosts: BlogPost[] = [
 				At its simplest, equity management is everything a company does to operate its stock and equity compensation programs. It spans strategy and design (what to grant and to whom), day-to-day operations (processing grants, vesting, exercises, and releases), compliance and reporting (tax, securities, and accounting obligations), and the participant experience (helping employees understand and act on their awards).
 			</p>
 			<p>
-				People sometimes use "equity management," "stock plan administration," and "equity compensation" interchangeably, but they aren't quite the same thing. Equity compensation refers to the awards themselves: the options, units, and shares a company grants. <a href="/services/equity-plan-administration">Stock plan administration</a> is the operational work of running those programs. Equity management is the broader umbrella that includes both the strategic and the operational sides of the discipline.
+				People sometimes use "equity management," "stock plan administration," and "equity compensation" interchangeably, but they aren’t quite the same thing. Equity compensation refers to the awards themselves: the options, units, and shares a company grants. <a href="/services/equity-plan-administration">Stock plan administration</a> is the operational work of running those programs. Equity management is the broader umbrella that includes both the strategic and the operational sides of the discipline.
 			</p>
 
 			<h2>The Main Types of Equity-Based Compensation</h2>
 			<p>
-				Effective equity management starts with understanding the instruments you're working with. Equity-based compensation comes in several forms, each with its own mechanics, tax treatment, and administrative requirements:
+				Effective equity management starts with understanding the instruments you’re working with. Equity-based compensation comes in several forms, each with its own mechanics, tax treatment, and administrative requirements:
 			</p>
 
 			<h3>Stock Options (ISOs and NSOs)</h3>
@@ -42,7 +42,7 @@ export const blogPosts: BlogPost[] = [
 
 			<h3>Restricted Stock Units (RSUs) and Awards (RSAs)</h3>
 			<p>
-				RSUs are a promise to deliver shares once vesting conditions are met, and they've become the most common form of equity compensation at many companies. Restricted Stock Awards (RSAs) are actual shares issued up front but subject to forfeiture until they vest.
+				RSUs are a promise to deliver shares once vesting conditions are met, and they’ve become the most common form of equity compensation at many companies. Restricted Stock Awards (RSAs) are actual shares issued up front but subject to forfeiture until they vest.
 			</p>
 
 			<h3>Performance Share Units (PSUs)</h3>
@@ -95,16 +95,16 @@ export const blogPosts: BlogPost[] = [
 				As programs grow, most companies reach a point where managing equity internally becomes a strain. The person responsible often wears several hats, juggling HR, payroll, or finance alongside equity. As volume and complexity climb, the "team of one" model starts to crack.
 			</p>
 			<p>
-				That's where an equity management company comes in. Rather than building and maintaining a full in-house team, you partner with specialists who live and breathe equity compensation. A good partner can take complete ownership of your program, augment your existing team, or step in for specific projects and peak periods.
+				That’s where an equity management company comes in. Rather than building and maintaining a full in-house team, you partner with specialists who live and breathe equity compensation. A good partner can take complete ownership of your program, augment your existing team, or step in for specific projects and peak periods.
 			</p>
 			<p>
 				Working with an equity management company typically makes sense when:
 			</p>
 			<ul>
 				<li>Your headcount and grant volume are growing faster than your capacity to manage them</li>
-				<li>You're preparing for an IPO, M&A transaction, or other liquidity event</li>
-				<li>Compliance obligations have outgrown your team's bandwidth or expertise</li>
-				<li>You're implementing or migrating to a new equity platform</li>
+				<li>You’re preparing for an IPO, M&A transaction, or other liquidity event</li>
+				<li>Compliance obligations have outgrown your team’s bandwidth or expertise</li>
+				<li>You’re implementing or migrating to a new equity platform</li>
 				<li>You need interim, fractional, or on-demand support during a vacancy or peak period</li>
 			</ul>
 
@@ -120,7 +120,7 @@ export const blogPosts: BlogPost[] = [
 
 			<h2>The Bottom Line</h2>
 			<p>
-				Equity management is far more than processing grants; it's a strategic discipline that touches talent, compliance, accounting, and the employee experience. Whether you build the capability in-house or partner with an equity management company, the goal is the same: a program that's accurate, compliant, and genuinely valuable to your people. If your equity workload is outpacing your capacity, it may be time to <a href="/contact">explore your options</a>.
+				Equity management is far more than processing grants; it’s a strategic discipline that touches talent, compliance, accounting, and the employee experience. Whether you build the capability in-house or partner with an equity management company, the goal is the same: a program that’s accurate, compliant, and genuinely valuable to your people. If your equity workload is outpacing your capacity, it may be time to <a href="/contact">explore your options</a>.
 			</p>
 		`
 	},

--- a/src/lib/data/blogPosts.ts
+++ b/src/lib/data/blogPosts.ts
@@ -2,6 +2,129 @@ import type { BlogPost } from '$lib/types';
 
 export const blogPosts: BlogPost[] = [
 	{
+		slug: 'what-is-equity-management',
+		title: 'What Is Equity Management? A Complete Guide for Companies',
+		metaTitle: 'What Is Equity Management? A Guide for Companies | Accelerated Equity Plans',
+		metaDescription:
+			'Equity management is the end-to-end administration of a company’s equity-based compensation. Learn what it involves, the types of equity comp, and when to partner with an equity management company.',
+		excerpt:
+			'Equity management covers everything from issuing grants to staying compliant. Here’s what it actually involves, the main types of equity-based compensation, and how to decide between managing it in-house or partnering with an equity management company.',
+		publishedDate: '2026-06-12',
+		author: {
+			name: 'Emily Bone, MBA, CEP',
+			title: 'Founder & CEO'
+		},
+		category: 'Equity Management',
+		tags: ['equity management', 'equity based compensation', 'equity compensation', 'stock plans'],
+		readingTime: 11,
+		content: `
+			<p class="lead">
+				Equity management is the discipline of administering a company's equity-based compensation across its entire lifecycle, from designing a plan and issuing grants to tracking vesting, ensuring compliance, and supporting employees. Done well, it turns equity into a powerful tool for attracting and retaining talent. Done poorly, it creates compliance risk, accounting headaches, and frustrated employees. This guide explains what equity management involves, the main types of equity-based compensation, and how to decide whether to manage it in-house or partner with an equity management company.
+			</p>
+
+			<h2>What Is Equity Management?</h2>
+			<p>
+				At its simplest, equity management is everything a company does to operate its stock and equity compensation programs. It spans strategy and design (what to grant and to whom), day-to-day operations (processing grants, vesting, exercises, and releases), compliance and reporting (tax, securities, and accounting obligations), and the participant experience (helping employees understand and act on their awards).
+			</p>
+			<p>
+				People sometimes use "equity management," "stock plan administration," and "equity compensation" interchangeably, but they aren't quite the same thing. Equity compensation refers to the awards themselves; the options, units, and shares a company grants. <a href="/services/equity-plan-administration">Stock plan administration</a> is the operational work of running those programs. Equity management is the broader umbrella that includes both the strategic and the operational sides of the discipline.
+			</p>
+
+			<h2>The Main Types of Equity-Based Compensation</h2>
+			<p>
+				Effective equity management starts with understanding the instruments you're working with. Equity-based compensation comes in several forms, each with its own mechanics, tax treatment, and administrative requirements:
+			</p>
+
+			<h3>Stock Options (ISOs and NSOs)</h3>
+			<p>
+				Stock options give employees the right to purchase shares at a fixed price (the strike or exercise price) after they vest. Incentive Stock Options (ISOs) can offer favorable tax treatment but come with strict requirements, while Non-Qualified Stock Options (NSOs) are more flexible but taxed as ordinary income at exercise.
+			</p>
+
+			<h3>Restricted Stock Units (RSUs) and Awards (RSAs)</h3>
+			<p>
+				RSUs are a promise to deliver shares once vesting conditions are met, and they've become the most common form of equity compensation at many companies. Restricted Stock Awards (RSAs) are actual shares issued up front but subject to forfeiture until they vest.
+			</p>
+
+			<h3>Performance Share Units (PSUs)</h3>
+			<p>
+				PSUs vest based on the achievement of specific performance metrics, such as revenue targets or relative shareholder return, rather than just the passage of time. They tie equity rewards directly to business outcomes but add complexity to tracking and accounting.
+			</p>
+
+			<h3>Employee Stock Purchase Plans (ESPPs)</h3>
+			<p>
+				ESPPs let employees buy company stock, often at a discount, through payroll deductions. Qualified 423(b) plans carry specific tax and administrative rules, including Section 6039 reporting obligations.
+			</p>
+
+			<h3>Stock Appreciation Rights and Phantom Stock</h3>
+			<p>
+				Stock Appreciation Rights (SARs) pay out the increase in share value without requiring an actual purchase, while phantom stock delivers a cash equivalent tied to share price. Both let companies offer equity-like incentives without diluting ownership.
+			</p>
+
+			<h2>The Equity Management Lifecycle</h2>
+			<p>
+				Whatever instruments you use, managing them well means handling each stage of the grant lifecycle with accuracy and discipline:
+			</p>
+
+			<h3>Plan Design and Strategy</h3>
+			<p>
+				Strong equity management begins before a single grant is issued. <a href="/services/plan-process-design">Plan and process design</a> involves choosing the right award types, vesting schedules, performance metrics, and grant levels so your program is competitive, cost-effective, and aligned with your accounting and tax considerations.
+			</p>
+
+			<h3>Grant Administration</h3>
+			<p>
+				Once a plan is in place, the operational work begins: issuing grants, tracking vesting events, processing exercises and releases, and maintaining accurate records. This is the heart of day-to-day stock plan administration, and the area where errors are most costly.
+			</p>
+
+			<h3>Compliance and Reporting</h3>
+			<p>
+				Equity compensation is heavily regulated. Companies must navigate Section 16 reporting for insiders, ASC 718 expense calculations, Section 6039 information returns for ISOs and ESPPs, 409A valuations for private companies, and a range of securities and international tax requirements. Missing a filing or miscalculating an expense can carry real consequences.
+			</p>
+
+			<h3>System and Vendor Management</h3>
+			<p>
+				Most companies run their programs on a dedicated equity platform such as Carta, Shareworks, Fidelity, or Equity Edge Online. Selecting, implementing, and optimizing these systems, and integrating them with HRIS and payroll, is a discipline in itself. <a href="/services/vendor-support">Vendor support and implementation</a> ensures your technology actually delivers on its promise.
+			</p>
+
+			<h3>Strategic Transactions</h3>
+			<p>
+				Major events such as IPOs, mergers and acquisitions, and SPAC transactions create some of the most complex equity scenarios a company will face. <a href="/services/advanced-project-support">Advanced project support</a> for these transitions includes equity treatment analysis, due diligence, participant communications, and system migrations.
+			</p>
+
+			<h2>In-House vs. an Equity Management Company</h2>
+			<p>
+				As programs grow, most companies reach a point where managing equity internally becomes a strain. The person responsible often wears several hats; juggling HR, payroll, or finance alongside equity, and the "team of one" model starts to crack under increasing volume and complexity.
+			</p>
+			<p>
+				That's where an equity management company comes in. Rather than building and maintaining a full in-house team, you partner with specialists who live and breathe equity compensation. A good partner can take complete ownership of your program, augment your existing team, or step in for specific projects and peak periods.
+			</p>
+			<p>
+				Working with an equity management company typically makes sense when:
+			</p>
+			<ul>
+				<li>Your headcount and grant volume are growing faster than your capacity to manage them</li>
+				<li>You're preparing for an IPO, M&A transaction, or other liquidity event</li>
+				<li>Compliance obligations have outgrown your team's bandwidth or expertise</li>
+				<li>You're implementing or migrating to a new equity platform</li>
+				<li>You need interim, fractional, or on-demand support during a vacancy or peak period</li>
+			</ul>
+
+			<h2>What to Look for in an Equity Management Company</h2>
+			<p>
+				Not all providers are alike. When evaluating an equity management partner, look for deep, hands-on expertise across both private and public company programs; experience with your equity platform and the major vendors; a flexible engagement model that fits your needs rather than forcing you into a one-size-fits-all package; and direct access to senior professionals rather than a rotating cast of junior staff. The right partner becomes an extension of your team, reducing risk while freeing you to focus on strategy.
+			</p>
+
+			<h2>How Accelerated Equity Plans Approaches Equity Management</h2>
+			<p>
+				At Accelerated Equity Plans, we provide end-to-end equity management for private and public companies. Our services span <a href="/services/equity-plan-administration">stock plan administration</a>, <a href="/services/plan-process-design">plan and process design</a>, <a href="/services/vendor-support">vendor support</a>, and <a href="/services/advanced-project-support">advanced project support</a> for IPOs, M&A, and other strategic transactions. Founded by industry experts with both issuer and vendor experience, we offer flexible engagement models, from full outsourcing to targeted support, so you get exactly the expertise you need, when you need it.
+			</p>
+
+			<h2>The Bottom Line</h2>
+			<p>
+				Equity management is far more than processing grants; it's a strategic discipline that touches talent, compliance, accounting, and the employee experience. Whether you build the capability in-house or partner with an equity management company, the goal is the same: a program that's accurate, compliant, and genuinely valuable to your people. If your equity workload is outpacing your capacity, it may be time to <a href="/contact">explore your options</a>.
+			</p>
+		`
+	},
+	{
 		slug: 'do-i-need-equity-plan-administration-service',
 		title: 'Do I Need Assistance With My Equity Plan?',
 		metaTitle: 'Do I Need Assistance With My Equity Plan? | Accelerated Equity Plans',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,10 +24,9 @@
 
 	let isMobile = true;
 
-	const title =
-		'Equity Compensation Consulting Services for Your Business | Accelerated Equity Plans';
+	const title = 'Equity Management Company & Compensation Consulting | Accelerated Equity Plans';
 	const description =
-		'Unlock the full potential of your equity programs with expert equity compensation consulting and tailored administration solutions.';
+		'A dedicated equity management company offering expert equity compensation consulting, stock plan administration, and tailored solutions to unlock the full potential of your equity programs.';
 	const path = '/';
 
 	const updateWindowSize = () => {
@@ -145,14 +144,14 @@
 		<div class="overflow-hidden absolute inset-0">
 			{#if isMobile}
 				<enhanced:img
-					alt="High rise buildings"
+					alt="High-rise office buildings representing equity management and stock plan administration"
 					class="block object-cover lg:hidden size-full"
 					fetchpriority="high"
 					src={HeroBgMobile}
 				/>
 			{:else}
 				<enhanced:img
-					alt="High rise buildings"
+					alt="High-rise office buildings representing equity management and stock plan administration"
 					class="object-cover size-full"
 					fetchpriority="high"
 					src={HeroBg}
@@ -214,10 +213,21 @@
 			<RedBar classes="mx-auto" />
 			<h2 class={styles.h2}>What We Bring to the Table</h2>
 			<p class="mt-4 font-light">
-				We manage all stock plan administration from setup to compliance, allowing you to focus on
-				your core business. We offer temporary support with flexible staffing solutions and provide
-				expertise in Mergers and Acquisitions, IPOs, SPACs, Corporate Actions, and Automation Design
-				for strategic growth.
+				We manage all
+				<a
+					class="underline hover:text-red-300"
+					href={resolve('/services/equity-plan-administration')}
+				>
+					stock plan administration
+				</a>
+				from setup to compliance, allowing you to focus on your core business. We offer temporary support
+				with flexible staffing solutions and provide expertise in
+				<a
+					class="underline hover:text-red-300"
+					href={resolve('/services/advanced-project-support')}
+				>
+					Mergers and Acquisitions, IPOs, SPACs
+				</a>, Corporate Actions, and Automation Design for strategic growth.
 			</p>
 		</div>
 
@@ -246,7 +256,7 @@
 	<section class={clsx('relative bg-stone-700 py-24 px-6', 'lg:py-32')}>
 		<div class="overflow-hidden absolute inset-0">
 			<enhanced:img
-				alt="A building with a blurred background"
+				alt="Corporate office building representing comprehensive equity plan administration services"
 				class="hidden object-cover lg:block size-full"
 				loading="lazy"
 				src={BuildingBlurredBg}
@@ -327,9 +337,9 @@
 			</div>
 			<div class="font-light prose">
 				<p>
-					Accelerated Equity Plans partners with you to boost your team's effectiveness in equity
-					compensation. We handle plan adjustments, daily operations, and future strategy, allowing
-					you to focus on leading your company forward.
+					As a dedicated equity management company, Accelerated Equity Plans partners with you to
+					boost your team's effectiveness in equity compensation. We handle plan adjustments, daily
+					operations, and future strategy, allowing you to focus on leading your company forward.
 				</p>
 			</div>
 			<div class="flex gap-x-4">

--- a/src/routes/services/+page.svelte
+++ b/src/routes/services/+page.svelte
@@ -225,7 +225,7 @@
 	<section class={styles.heroSection}>
 		<div class="overflow-hidden absolute inset-0">
 			<enhanced:img
-				alt="High rise buildings"
+				alt="High-rise office buildings representing equity plan administration and consulting services"
 				class="object-cover size-full"
 				fetchpriority="high"
 				src={HeroBg}

--- a/src/routes/services/advanced-project-support/+page.svelte
+++ b/src/routes/services/advanced-project-support/+page.svelte
@@ -53,7 +53,7 @@
 		{
 			title: 'Merger & Acquisition Support',
 			description:
-				"Navigate equity complexities in M&A transactions. Our services include treatment analysis, participant communications, system consolidations, regulatory compliance, and post-merger integration to ensure equity compensation doesn't become a deal impediment."
+				"Navigate equity complexities in M&A transactions. Our services include equity compensation due diligence, treatment analysis, participant communications, system consolidations, regulatory compliance, and post-merger integration to ensure equity compensation doesn't become a deal impediment."
 		},
 		{
 			title: 'SPAC Transactions',
@@ -109,7 +109,12 @@
 		{
 			question: 'What M&A equity support do you provide?',
 			answer:
-				"<p>M&A transactions create complex equity scenarios requiring quick decisions and flawless execution. We provide equity treatment analysis (acceleration, conversion, cash-out scenarios), integration planning, participant communications, data consolidation, system migrations, regulatory compliance support, and post-merger administration. Whether you're the acquirer or target, our experience helps you avoid common pitfalls and ensure equity doesn't impede deal closure.</p>"
+				"<p>M&A transactions create complex equity scenarios requiring quick decisions and flawless execution. We provide equity compensation due diligence, equity treatment analysis (acceleration, conversion, cash-out scenarios), integration planning, participant communications, data consolidation, system migrations, regulatory compliance support, and post-merger administration. Whether you're the acquirer or target, our experience helps you avoid common pitfalls and ensure equity doesn't impede deal closure.</p>"
+		},
+		{
+			question: 'Do you perform equity compensation due diligence?',
+			answer:
+				'<p>Yes. As part of M&A and other strategic transactions, we conduct equity compensation due diligence to surface risks and obligations before a deal closes. This includes reviewing outstanding grants and vesting terms, change-in-control and acceleration provisions, plan documents and share reserves, dilution and overhang analysis, tax and accounting exposure, and compliance gaps. We deliver a clear picture of the target’s equity landscape so you can negotiate and plan integration with confidence.</p>'
 		},
 		{
 			question: 'Can you help automate our equity processes?',

--- a/src/routes/services/advanced-project-support/+page.svelte
+++ b/src/routes/services/advanced-project-support/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import CustomerReviews from '$lib/components/CustomerReviews.svelte';
 	import FAQ from '$lib/components/FAQ.svelte';
@@ -230,10 +231,11 @@
 				<h2 class={styles.h2}>Expert Support for Complex Equity Initiatives</h2>
 				<div class="prose max-w-4xl text-lg text-stone-700 font-light">
 					<p>
-						Major equity projects—whether an IPO, M&A transaction, global expansion, or technology
-						transformation—represent critical moments for your organization. Success requires
-						specialized expertise, careful planning, and flawless execution. Mistakes can be costly,
-						both financially and reputationally.
+						Major equity projects—whether an IPO, M&A transaction, global expansion, or a
+						<a href={resolve('/services/vendor-support')}>technology platform transformation</a
+						>—represent critical moments for your organization. Success requires specialized
+						expertise, careful planning, and flawless execution. Mistakes can be costly, both
+						financially and reputationally.
 					</p>
 					<p>
 						AEP brings deep, specialized knowledge gained from managing hundreds of complex equity

--- a/src/routes/services/equity-plan-administration/+page.svelte
+++ b/src/routes/services/equity-plan-administration/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import CustomerReviews from '$lib/components/CustomerReviews.svelte';
 	import FAQ from '$lib/components/FAQ.svelte';
@@ -302,10 +303,13 @@
 				<div>
 					<h3 class={clsx(styles.h3, 'text-stone-900')}>Companies Undergoing Transitions</h3>
 					<p class="font-light">
-						Whether you're preparing for an IPO, navigating an M&A transaction, implementing a new
-						equity platform, or experiencing rapid growth, transitions create unique challenges. Our
-						team has extensive experience supporting companies through these critical periods,
-						providing the expertise and bandwidth you need exactly when you need it most.
+						Whether you're <a href={resolve('/services/advanced-project-support')}
+							>preparing for an IPO or navigating an M&A transaction</a
+						>,
+						<a href={resolve('/services/vendor-support')}>implementing a new equity platform</a>, or
+						experiencing rapid growth, transitions create unique challenges. Our team has extensive
+						experience supporting companies through these critical periods, providing the expertise
+						and bandwidth you need exactly when you need it most.
 					</p>
 				</div>
 			</div>

--- a/src/routes/services/equity-plan-administration/+page.svelte
+++ b/src/routes/services/equity-plan-administration/+page.svelte
@@ -12,9 +12,9 @@
 	import { styles } from '$lib/styles';
 	import { clsx } from 'clsx';
 
-	const title = 'Expert Equity Plan Administration Services | Accelerated Equity Plans';
+	const title = 'Stock Plan & Equity Plan Administration Services | Accelerated Equity Plans';
 	const description =
-		'Professional equity plan administration services including comprehensive equity management, employee education, outsourced administration, and scalable support for private and public companies.';
+		'Outsourced stock plan administration and equity plan administration services—comprehensive equity management, employee education, and interim, fractional, and on-demand support for private and public companies.';
 	const path = '/services/equity-plan-administration';
 
 	const features = [
@@ -38,9 +38,9 @@
 		},
 		{
 			icon: Graph,
-			title: 'Seasonal & Temporary Support',
+			title: 'Interim, Fractional & On-Demand Support',
 			description:
-				'Navigate peak periods with confidence. Our temporary staffing solutions provide experienced equity professionals exactly when you need them most—during annual grant cycles, year-end reporting, M&A transactions, or other high-volume periods. Seamlessly integrate our experts into your workflow without long-term commitments.'
+				'Navigate peak periods with confidence. Whether you need an interim stock plan administrator to cover a vacancy, a fractional administrator for part-time ongoing coverage, or on-demand stock administration during annual grant cycles, year-end reporting, or M&A transactions, we provide experienced equity professionals exactly when you need them—without long-term commitments.'
 		}
 	];
 
@@ -96,7 +96,17 @@
 		{
 			question: 'Can you help with equity compensation reporting and compliance?',
 			answer:
-				'<p>Absolutely. We provide comprehensive support for all equity-related reporting requirements including Form 3, 4, and 5 filings for Section 16 officers, proxy statement preparation, ASC 718 expense calculations, 423(b) ESPP compliance, and more. We stay current with regulatory changes and proactively adapt your program to maintain compliance.</p>'
+				'<p>Absolutely. We provide comprehensive support for all equity-related reporting requirements including Form 3, 4, and 5 filings for Section 16 officers, proxy statement preparation, ASC 718 expense calculations, Section 6039 information returns, 423(b) ESPP compliance, and more. We stay current with regulatory changes and proactively adapt your program to maintain compliance.</p>'
+		},
+		{
+			question: 'Do you handle Section 6039 reporting for ISOs and ESPPs?',
+			answer:
+				'<p>Yes. We manage the full Section 6039 reporting process, including preparing and furnishing Form 3921 for incentive stock option (ISO) exercises and Form 3922 for ESPP share transfers, distributing participant statements by the January 31 deadline, and filing the corresponding information returns with the IRS. We reconcile the underlying transaction data against your equity platform to ensure every reportable event is captured accurately and on time.</p>'
+		},
+		{
+			question: 'Can you provide an interim or fractional stock plan administrator?',
+			answer:
+				'<p>Yes. We offer interim stock plan administrators to cover a vacancy or leave of absence, fractional administrators who manage your program on a part-time, ongoing basis, and on-demand stock administration for short-term, project-based needs. This flexibility lets you maintain seamless administration and compliance without the cost or commitment of a full-time hire.</p>'
 		},
 		{
 			question: 'What makes your equity administration services different?',
@@ -169,7 +179,9 @@
 		<div class={clsx('relative grid gap-8', 'md:text-center')}>
 			<div class="grid gap-4">
 				<RedBar classes="md:mx-auto" />
-				<h1 class={clsx(styles.h1, 'text-white')}>Expert Equity Plan Administration Services</h1>
+				<h1 class={clsx(styles.h1, 'text-white')}>
+					Expert Stock Plan & Equity Plan Administration Services
+				</h1>
 			</div>
 			<p class="mx-auto max-w-3xl text-lg font-light text-white">
 				Expert administration services that simplify your equity compensation program. From grant
@@ -190,10 +202,10 @@
 		<div class="mx-auto max-w-7xl">
 			<div class="grid gap-8 mb-16">
 				<RedBar />
-				<h2 class={styles.h2}>Comprehensive Equity Plan Administration</h2>
+				<h2 class={styles.h2}>Comprehensive Stock Plan & Equity Plan Administration</h2>
 				<div class="prose max-w-4xl text-lg text-stone-700 font-light">
 					<p>
-						Managing equity compensation programs has become increasingly complex. Between evolving
+						Managing stock plan administration has become increasingly complex. Between evolving
 						regulatory requirements, sophisticated technology platforms, and the need to provide
 						excellent participant experiences, many companies find themselves stretched thin trying
 						to manage it all internally.
@@ -202,9 +214,9 @@
 						At Accelerated Equity Plans, we specialize in taking this burden off your shoulders. Our
 						team of dedicated equity professionals delivers tailored solutions that ensure
 						regulatory compliance, streamline operations, and create positive experiences for your
-						employees. Whether you need full outsourcing, targeted support for specific functions,
-						or temporary assistance during peak periods, we have the expertise and flexibility to
-						meet your needs.
+						employees. Whether you need fully outsourced stock plan administration, targeted support
+						for specific functions, or an interim, fractional, or on-demand stock plan administrator
+						during peak periods, we have the expertise and flexibility to meet your needs.
 					</p>
 					<p>
 						Our approach is built on three core principles: expertise, efficiency, and partnership.

--- a/src/routes/services/vendor-support/+page.svelte
+++ b/src/routes/services/vendor-support/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import CustomerReviews from '$lib/components/CustomerReviews.svelte';
 	import FAQ from '$lib/components/FAQ.svelte';
@@ -236,9 +237,10 @@
 					<p>
 						Whether you're selecting a new vendor, implementing a platform, migrating from a legacy
 						system, or looking to optimize your current setup, AEP provides the specialized
-						knowledge and hands-on support you need. Our team has implemented and administered
-						equity systems across all major platforms, giving us unique insight into what works,
-						what doesn't, and how to avoid common pitfalls.
+						knowledge and hands-on support you need. Our team has implemented and provides ongoing
+						<a href={resolve('/services/equity-plan-administration')}>stock plan administration</a> across
+						all major platforms, giving us unique insight into what works, what doesn't, and how to avoid
+						common pitfalls.
 					</p>
 					<p>
 						We take a vendor-agnostic approach, focused solely on your success rather than platform

--- a/src/routes/services/vendor-support/+page.svelte
+++ b/src/routes/services/vendor-support/+page.svelte
@@ -45,7 +45,7 @@
 	];
 
 	const platforms = [
-		'E*TRADE Equity Edge (Morgan Stanley)',
+		'E*TRADE Equity Edge Online (Morgan Stanley at Work)',
 		'Morgan Stanley Shareworks',
 		'Fidelity Stock Plan Services (PSW)',
 		'Schwab Equiview',
@@ -53,6 +53,29 @@
 		'Computershare (EquatePlus)',
 		'Certent Equity Management',
 		'Global Shares'
+	];
+
+	const platformSupport = [
+		{
+			title: 'Carta Administration Support',
+			description:
+				'From initial implementation to day-to-day Carta equity administration, our team helps you configure your cap table, automate grant and vesting workflows, run 409A and ASC 718 reporting, and resolve the issues that slow your team down. Whether you are moving onto Carta or optimizing an existing instance, we bring hands-on expertise.'
+		},
+		{
+			title: 'Shareworks Administration Support',
+			description:
+				'We provide expert Shareworks (Morgan Stanley at Work) administration support, including implementation, data migration, participant management, reporting, and ongoing optimization. Our team helps you unlock the platform’s advanced capabilities and keep your equity program running smoothly.'
+		},
+		{
+			title: 'Fidelity Stock Plan Services Support',
+			description:
+				'Get specialized support for Fidelity Stock Plan Services (PSW), from onboarding and data conversion to grant processing, reconciliation, and reporting. We help you streamline operations and make the most of your Fidelity platform.'
+		},
+		{
+			title: 'Equity Edge Online Support',
+			description:
+				'Our team offers deep Equity Edge Online (EEO) support and administration, covering implementation, configuration, transaction processing, tax reporting, and integrations. We help E*TRADE / Morgan Stanley at Work clients optimize EEO and reduce manual work.'
+		}
 	];
 
 	const benefits = [
@@ -271,6 +294,29 @@
 			<p class="text-center mt-8 text-stone-400 font-light">
 				...and many other equity management platforms
 			</p>
+		</div>
+	</section>
+
+	<section class="py-24 px-6 bg-white">
+		<div class="mx-auto max-w-7xl">
+			<div class="grid gap-8 mb-12">
+				<RedBar />
+				<h2 class={styles.h2}>Platform-Specific Support</h2>
+				<p class="prose max-w-4xl text-lg text-stone-700 font-light">
+					Need help with a specific equity platform? Our administrators work in these systems every
+					day. Below are a few of the platforms we support most often—each engagement is tailored to
+					your configuration, data, and team.
+				</p>
+			</div>
+
+			<div class={clsx('grid gap-6', 'md:grid-cols-2')}>
+				{#each platformSupport as platform (platform.title)}
+					<div class="p-8 bg-stone-50 rounded-lg border border-stone-200">
+						<h3 class={clsx(styles.h3, 'mb-4 text-stone-900')}>{platform.title}</h3>
+						<p class="text-stone-700 font-light leading-relaxed">{platform.description}</p>
+					</div>
+				{/each}
+			</div>
 		</div>
 	</section>
 


### PR DESCRIPTION
## What changed

On-page SEO optimization targeting keyword gaps identified in an audit of the current ranking list against site content, plus a new pillar blog post for high-volume head terms. No functional/visual changes beyond added copy, links, metadata, and one new article.

### Keyword targeting (service pages)

**Equity Plan Administration page** (`/services/equity-plan-administration`)
- Title, meta description, and H1 now target the **stock plan administration** keyword cluster alongside the existing **equity plan administration** terms (the page already ranks #1 for the latter; body copy used "stock plan administration" but titles did not).
- Renamed "Seasonal & Temporary Support" feature to "Interim, Fractional & On-Demand Support" to target those role-based searches.
- Added FAQs for **Section 6039 reporting** (Form 3921/3922) and interim/fractional/on-demand administrator engagements.

**Vendor Support page** (`/services/vendor-support`)
- Added a **Platform-Specific Support** section with H3s targeting *Carta administration support*, *Shareworks administration support*, *Fidelity Stock Plan Services support*, and *Equity Edge Online support* (previously these platforms were only name-dropped in a list).
- Named **Equity Edge Online** explicitly in the supported-platforms list.

**Advanced Project Support page** (`/services/advanced-project-support`)
- Added **equity compensation due diligence** to the M&A feature and FAQ, plus a dedicated due-diligence FAQ.

### Head terms, alt text & internal linking

- **Homepage** title/meta now target **equity management company** and **equity management** (the two highest-volume tracked keywords, ~2,100 and ~800/mo, previously untargeted).
- Replaced generic image **alt text** ("High rise buildings", "A building with a blurred background") with descriptive, keyword-relevant text on the homepage and services landing page.
- Added contextual **internal links** from the homepage into the service pages and **cross-links among the service pages** (admin ↔ vendor ↔ advanced-project), using `resolve()` to satisfy the `svelte/no-navigation-without-resolve` lint rule.

### New pillar content

- Added a comprehensive blog post, **"What Is Equity Management? A Complete Guide for Companies"** (`/blog/what-is-equity-management`), targeting the **equity management** (~2,100/mo), **equity management company** (~800/mo), and **equity based compensation** (~250/mo) head terms that no existing page addressed well.
- The post covers equity-comp instrument types, the equity management lifecycle, and in-house vs. partnering with an equity management company, with **8 internal links** into all four service pages and the contact page.
- Picked up automatically by the dynamic sitemap and blog listing; renders full `BlogPosting` Schema.org markup via the existing template.
- **Copy-edited** for clarity (fixed two incorrect semicolons, split an overloaded sentence, removed filler, replaced a vague consequence phrase with specific outcomes) and **normalized apostrophes to curly** throughout the post body to match the meta description and excerpt.

## How to test

- `bun run lint` — passes
- `bun run build` — succeeds
- Smoke-tested via `bun run preview`: `/blog/what-is-equity-management` returns 200, appears in `/sitemap.xml` and `/blog`, and renders its internal links.
- Review the homepage, three service pages, and the new blog post.

## Notes

`bun run check` reports 4 pre-existing type errors in untouched files (`gtag` window typing in ContactForm/JobApplicationForm, `@fontsource-variable` module declarations in the root layout). Not introduced by this PR.