### PR TITLE
Split team into leadership and AEP sections, remove Jordan Sims

### DIFF
--- a/src/lib/components/MeetTheTeam.svelte
+++ b/src/lib/components/MeetTheTeam.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import { leadershipTeam } from '$lib/data/leadershipTeam';
+	import { aepTeam, leadershipTeam } from '$lib/data/leadershipTeam';
 	import { styles } from '$lib/styles';
 	import { clsx } from 'clsx';
 	import RedBar from './RedBar.svelte';
@@ -16,74 +16,93 @@
 	id="meet-the-team"
 >
 	<div class="absolute inset-0 bg-stone-400/30"></div>
-	<div class="grid relative gap-12 mx-auto max-w-7xl">
-		<div class="grid gap-4">
-			<RedBar />
-			<h2 class={styles.h2}>Meet the leadership team</h2>
-			<div class="font-light prose prose-invert">
-				<p>
-					As subject matter experts, we can provide your organization with a complete Stock Plan
-					Administration team to handle all equity concerns!
-				</p>
+	<div class="grid relative gap-16 mx-auto max-w-7xl">
+		<div class="grid gap-12">
+			<div class="grid gap-4">
+				<RedBar />
+				<h2 class={styles.h2}>Meet the leadership team</h2>
+				<div class="font-light prose prose-invert">
+					<p>
+						As subject matter experts, we can provide your organization with a complete Stock Plan
+						Administration team to handle all equity concerns!
+					</p>
+				</div>
+			</div>
+
+			<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+				{#each leadershipTeam as teamMember (teamMember.fullName)}
+					{@render teamCard(teamMember)}
+				{/each}
 			</div>
 		</div>
 
-		<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-			{#each leadershipTeam as teamMember (teamMember.fullName)}
-				<div class={clsx(styles.blueRedGradientBackground, styles.cardHover, 'group')}>
-					<div class="flex flex-col gap-4 justify-start p-8 h-full bg-black rounded-lg [&_ul]:mb-8">
-						<enhanced:img
-							alt={teamMember.imageAlt}
-							class={clsx(
-								'aspect-square mt-4 rounded-full object-cover max-w-[200px] shadow-lg grayscale transition-all',
-								'group-hover:grayscale-0'
-							)}
-							loading="lazy"
-							src={teamMember.imageSrc}
-						/>
-						<div class={clsx('flex flex-col grow prose prose-invert')}>
-							<div class="grow">
-								<h3 class={styles.h3}>
-									{teamMember.fullName}
-								</h3>
-								<div class="font-light">
-									<h4>Specialties</h4>
-									<ul class="mb-8 flex flex-wrap gap-x-1.5 pl-0 list-none">
-										{#each teamMember.specialties as specialty (specialty)}
-											<li
-												class={clsx(
-													'py-1.5 px-3 rounded-2xl bg-stone-700 text-xs',
-													'md:gap-1.5 md:px-3 md:text-sm'
-												)}
-											>
-												{specialty}
-											</li>
-										{/each}
-									</ul>
-								</div>
-								<div class="font-light">
-									{@html teamMember.body}
-								</div>
-							</div>
-							<div class="flex flex-wrap gap-x-6 justify-between mt-6 list-none">
-								<a href={resolve('/contact')} class={styles.darkButton}>
-									Meet {teamMember.shortName}
-								</a>
-								{#if teamMember.linkedInLink}
-									<a
-										aria-label={`${teamMember.shortName}'s LinkedIn page`}
-										href={teamMember.linkedInLink}
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										<LinkedIn /></a
-									>
-								{/if}
-							</div>
-						</div>
-					</div>
-				</div>
-			{/each}
+		<div class="grid gap-12">
+			<div class="grid gap-4">
+				<RedBar />
+				<h2 class={styles.h2}>Meet the AEP team</h2>
+			</div>
+
+			<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+				{#each aepTeam as teamMember (teamMember.fullName)}
+					{@render teamCard(teamMember)}
+				{/each}
+			</div>
 		</div>
 	</div>
 </section>
+
+{#snippet teamCard(teamMember: (typeof leadershipTeam)[number])}
+	<div class={clsx(styles.blueRedGradientBackground, styles.cardHover, 'group')}>
+		<div class="flex flex-col gap-4 justify-start p-8 h-full bg-black rounded-lg [&_ul]:mb-8">
+			<enhanced:img
+				alt={teamMember.imageAlt}
+				class={clsx(
+					'aspect-square mt-4 rounded-full object-cover max-w-[200px] shadow-lg grayscale transition-all',
+					'group-hover:grayscale-0'
+				)}
+				loading="lazy"
+				src={teamMember.imageSrc}
+			/>
+			<div class={clsx('flex flex-col grow prose prose-invert')}>
+				<div class="grow">
+					<h3 class={styles.h3}>
+						{teamMember.fullName}
+					</h3>
+					<div class="font-light">
+						<h4>Specialties</h4>
+						<ul class="mb-8 flex flex-wrap gap-x-1.5 pl-0 list-none">
+							{#each teamMember.specialties as specialty (specialty)}
+								<li
+									class={clsx(
+										'py-1.5 px-3 rounded-2xl bg-stone-700 text-xs',
+										'md:gap-1.5 md:px-3 md:text-sm'
+									)}
+								>
+									{specialty}
+								</li>
+							{/each}
+						</ul>
+					</div>
+					<div class="font-light">
+						{@html teamMember.body}
+					</div>
+				</div>
+				<div class="flex flex-wrap gap-x-6 justify-between mt-6 list-none">
+					<a href={resolve('/contact')} class={styles.darkButton}>
+						Meet {teamMember.shortName}
+					</a>
+					{#if teamMember.linkedInLink}
+						<a
+							aria-label={`${teamMember.shortName}'s LinkedIn page`}
+							href={teamMember.linkedInLink}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<LinkedIn /></a
+						>
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{/snippet}

--- a/src/lib/components/MeetTheTeam.svelte
+++ b/src/lib/components/MeetTheTeam.svelte
@@ -9,19 +9,19 @@
 
 <section
 	class={clsx(
-		'relative bg-stone-700 bg-repeat bg-center py-24 px-6 bg-cover text-white',
+		'relative bg-stone-700 bg-center bg-cover bg-repeat px-6 py-24 text-white',
 		'lg:py-32'
 	)}
 	style="background-image: url('/images/patterns/Pattern-0224_Pattern-Arrows.svg')"
 	id="meet-the-team"
 >
 	<div class="absolute inset-0 bg-stone-400/30"></div>
-	<div class="grid relative gap-16 mx-auto max-w-7xl">
-		<div class="grid gap-12">
+	<div class="relative mx-auto grid max-w-7xl gap-20">
+		<div class="grid gap-10">
 			<div class="grid gap-4">
 				<RedBar />
-				<h2 class={styles.h2}>Meet the leadership team</h2>
-				<div class="font-light prose prose-invert">
+				<h2 class={clsx(styles.h2, 'max-w-[24ch] text-balance')}>Meet the leadership team</h2>
+				<div class="prose prose-invert max-w-[64ch] font-light">
 					<p>
 						As subject matter experts, we can provide your organization with a complete Stock Plan
 						Administration team to handle all equity concerns!
@@ -29,54 +29,70 @@
 				</div>
 			</div>
 
-			<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+			<ul role="list" class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
 				{#each leadershipTeam as teamMember (teamMember.fullName)}
-					{@render teamCard(teamMember)}
+					{@render teamCard(teamMember, true)}
 				{/each}
-			</div>
+			</ul>
 		</div>
 
-		<div class="grid gap-12">
+		<div class="grid gap-10">
 			<div class="grid gap-4">
 				<RedBar />
-				<h2 class={styles.h2}>Meet the AEP team</h2>
+				<h3 class={clsx(styles.h3, 'max-w-[24ch] text-balance')}>Meet the AEP team</h3>
+				<div class="prose prose-invert max-w-[64ch] font-light">
+					<p>The consultants and specialists who deliver on your equity programs every day.</p>
+				</div>
 			</div>
 
-			<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+			<ul role="list" class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
 				{#each aepTeam as teamMember (teamMember.fullName)}
-					{@render teamCard(teamMember)}
+					{@render teamCard(teamMember, false)}
 				{/each}
-			</div>
+			</ul>
 		</div>
 	</div>
 </section>
 
-{#snippet teamCard(teamMember: (typeof leadershipTeam)[number])}
-	<div class={clsx(styles.blueRedGradientBackground, styles.cardHover, 'group')}>
-		<div class="flex flex-col gap-4 justify-start p-8 h-full bg-black rounded-lg [&_ul]:mb-8">
+{#snippet teamCard(teamMember: (typeof leadershipTeam)[number], featured: boolean)}
+	<li
+		class={clsx(
+			'group',
+			styles.cardHover,
+			featured ? styles.blueRedGradientBackground : 'rounded-lg'
+		)}
+	>
+		<div
+			class={clsx(
+				'flex h-full flex-col rounded-lg bg-black [&_ul]:mb-8',
+				featured ? 'gap-4 p-8' : 'gap-4 p-6 ring-1 ring-white/10'
+			)}
+		>
 			<enhanced:img
-				alt={teamMember.imageAlt}
+				alt=""
 				class={clsx(
-					'aspect-square mt-4 rounded-full object-cover max-w-[200px] shadow-lg grayscale transition-all',
-					'group-hover:grayscale-0'
+					'aspect-square rounded-full object-cover outline-1 -outline-offset-1 outline-white/10 grayscale transition-all',
+					'group-hover:grayscale-0',
+					featured ? 'mt-4 max-w-[200px] shadow-lg' : 'max-w-[144px]'
 				)}
 				loading="lazy"
 				src={teamMember.imageSrc}
 			/>
-			<div class={clsx('flex flex-col grow prose prose-invert')}>
+			<div class="flex grow flex-col prose prose-invert">
 				<div class="grow">
-					<h3 class={styles.h3}>
+					<h3
+						class={featured
+							? styles.h3
+							: 'mt-0 font-headings text-xl font-medium tracking-tight text-pretty italic sm:text-2xl'}
+					>
 						{teamMember.fullName}
 					</h3>
 					<div class="font-light">
 						<h4>Specialties</h4>
-						<ul class="mb-8 flex flex-wrap gap-x-1.5 pl-0 list-none">
+						<ul class="flex list-none flex-wrap gap-x-1.5 pl-0">
 							{#each teamMember.specialties as specialty (specialty)}
 								<li
-									class={clsx(
-										'py-1.5 px-3 rounded-2xl bg-stone-700 text-xs',
-										'md:gap-1.5 md:px-3 md:text-sm'
-									)}
+									class={clsx('rounded-2xl bg-stone-700 px-3 py-1.5 text-xs', 'md:px-3 md:text-sm')}
 								>
 									{specialty}
 								</li>
@@ -87,7 +103,7 @@
 						{@html teamMember.body}
 					</div>
 				</div>
-				<div class="flex flex-wrap gap-x-6 justify-between mt-6 list-none">
+				<div class="mt-6 flex flex-wrap justify-between gap-x-6 list-none">
 					<a href={resolve('/contact')} class={styles.darkButton}>
 						Meet {teamMember.shortName}
 					</a>
@@ -98,11 +114,11 @@
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							<LinkedIn /></a
-						>
+							<LinkedIn />
+						</a>
 					{/if}
 				</div>
 			</div>
 		</div>
-	</div>
+	</li>
 {/snippet}

--- a/src/lib/data/leadershipTeam.ts
+++ b/src/lib/data/leadershipTeam.ts
@@ -5,7 +5,6 @@ import KaelynnHeadShot from '../images/head-shots/kaelynn-head-shot.jpg?enhanced
 import EmHeadShot from '../images/head-shots/emily-head-shot.jpg?enhanced';
 import GraceHeadShot from '../images/head-shots/grace-head-shot.jpg?enhanced';
 import JoshHeadShot from '../images/head-shots/josh-head-shot.jpg?enhanced';
-import JordanHeadShot from '../images/head-shots/jordan-head-shot.jpg?enhanced';
 import NeilHeadShot from '../images/head-shots/neil-head-shot.jpg?enhanced';
 
 export const leadershipTeam = [
@@ -83,8 +82,10 @@ export const leadershipTeam = [
         </div>
         `,
 		linkedInLink: 'https://www.linkedin.com/in/aaron-rosser-cep-1604924a/'
-	},
+	}
+];
 
+export const aepTeam = [
 	{
 		fullName: 'Barbara Gunnufson, CEP',
 		shortName: 'Barbara',
@@ -160,31 +161,6 @@ export const leadershipTeam = [
 		linkedInLink: 'https://www.linkedin.com/in/gsegui/'
 	},
 	{
-		fullName: 'Jordan Sims, CEP',
-		shortName: 'Jordan',
-		imageSrc: JordanHeadShot,
-		imageAlt: 'Jordan Sims',
-		specialties: [
-			'Process Strategy and Implementation',
-			'Equity Compensation and Analysis',
-			'Shareworks Specialist',
-			'Risk Analysis and Improvements',
-			'Project Management'
-		],
-		body: `
-        <div>
-            <p>
-                Jordan has worked in finance for the past 12 years. Starting at Jordan Credit Union (yes, he was Jordan from Jordan Credit Union) to working within the equity compensation industry over the last 4 years, he has experienced a wide breadth of personal finance, specializing in Private Market equity compensation as a Client Success Manager and a Secondaries Transactions Specialist.
-            </p>
-            <p>
-                Jordan specializes in finding ways to build and improve process enhancements and excels in finding ways to work smarter rather than harder. As a Morgan Stanley CSM, he spent his time as the primary dedicated CSM for various high profile franchise clients. He specializes in RSU Releases, Administration Setup, and many other areas within the Equity Atmosphere. Jordan is based in Saratoga Springs, Utah, and in his free time he loves spending time with his wife and two daughters. If you bring up baseball with him... just be aware you won't be able to leave the conversation at a reasonable time!
-            </p>
-        </div>
-        `,
-		linkedInLink: 'https://www.linkedin.com/in/jordan-sims-financial-services/'
-	},
-
-	{
 		fullName: 'Kaelynn Jones, CEP',
 		shortName: 'Kaelynn',
 		imageSrc: KaelynnHeadShot,
@@ -238,3 +214,5 @@ export const leadershipTeam = [
 		linkedInLink: 'http://www.linkedin.com/in/cameron-cazier-1008523a7'
 	}
 ];
+
+export const allTeamMembers = [...leadershipTeam, ...aepTeam];

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,7 +14,7 @@
 	import { FaRectangleList } from 'svelte-icons-pack/fa';
 	import { IoPeople } from 'svelte-icons-pack/io';
 	import type { IconType } from 'svelte-icons-pack';
-	import { leadershipTeam } from '$lib/data/leadershipTeam';
+	import { allTeamMembers } from '$lib/data/leadershipTeam';
 	import { reviews } from '$lib/reviews';
 
 	onMount(() => {
@@ -148,7 +148,7 @@
 			email: 'info@acceleratedep.com',
 			telephone: '+1-801-808-6238',
 			sameAs: ['https://www.linkedin.com/company/accelerated-equity-plans/'],
-			member: leadershipTeam.map((member) => ({
+			member: allTeamMembers.map((member) => ({
 				'@type': 'Person',
 				'@context': 'https://schema.org',
 				name: member.fullName,


### PR DESCRIPTION
## What changed

- Removed Jordan Sims from the team data (entry and unused headshot import).
- Split the remaining members into two arrays in `leadershipTeam.ts`:
  - `leadershipTeam` — Emily Bone, Neil Birrell, Aaron Rosser
  - `aepTeam` — Barbara Gunnufson, Josh Ludlow, Grace Segui, Kaelynn Jones, Cam Cazier
- Added a combined `allTeamMembers` export.
- `MeetTheTeam.svelte` now renders two sections — "Meet the leadership team" and "Meet the AEP team" — sharing a single `teamCard` snippet for identical card markup.
- Organization JSON-LD in `+layout.svelte` now maps over `allTeamMembers`, so every member (minus Jordan) remains in structured data regardless of section.

## How to test

1. `bun run dev` and open the page containing the team section.
2. Confirm two sections render: leadership (Emily, Neil, Aaron) and AEP team (Barbara, Josh, Grace, Kaelynn, Cam).
3. Confirm Jordan Sims no longer appears anywhere.
4. View page source / structured data and confirm the Organization `member` list contains all 8 remaining members.

## Notes

- `bun run lint` passes clean (Prettier + ESLint).
- Pre-existing `bun run check`/`bun run build` failures (missing `.env` vars such as `TURNSTILE_SITE_KEY`/`ZOHO_CONTACT_FORM_URL`, `gtag`/fontsource type declarations) are unrelated to these changes.
- The "Meet the AEP team" section currently has no intro paragraph under its heading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team page now shows separate Leadership and AEP sections and renders all team members.

* **Updates**
  * Standardized team member cards and layout; contact and LinkedIn links included when available.
  * Jordan Sims, CEP removed from the roster.
  * Site structured data updated to include the combined team list for search engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->