### PR TITLE
Improve sitewide SEO targeting

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,6 @@
 declare global {
+	type GtagFunction = (command: string, target: string, parameters?: Record<string, unknown>) => void;
+
 	interface Turnstile {
 		render: (
 			container: string | HTMLElement,
@@ -19,6 +21,7 @@ declare global {
 
 	interface Window {
 		$zoho: unknown;
+		gtag: GtagFunction;
 		turnstile?: Turnstile;
 	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,5 +1,10 @@
 declare global {
-	type GtagFunction = (command: string, target: string, parameters?: Record<string, unknown>) => void;
+	type GtagFunction = {
+		(command: 'js', config: Date): void;
+		(command: 'config', target: string, parameters?: Record<string, unknown>): void;
+		(command: 'event', target: string, parameters?: Record<string, unknown>): void;
+		(command: string, target: string | Date, parameters?: Record<string, unknown>): void;
+	};
 
 	interface Turnstile {
 		render: (

--- a/src/fontsource.d.ts
+++ b/src/fontsource.d.ts
@@ -1,0 +1,4 @@
+declare module '@fontsource-variable/roboto';
+declare module '@fontsource-variable/archivo';
+declare module '@fontsource-variable/roboto/*';
+declare module '@fontsource-variable/archivo/*';

--- a/src/lib/components/ContactForm.svelte
+++ b/src/lib/components/ContactForm.svelte
@@ -123,8 +123,7 @@
 						name={field.name}
 						placeholder={field.placeholder ?? ''}
 						required={field.required}
-						rows={5}
-					></textarea>
+						rows={5}></textarea>
 				{:else}
 					<input
 						class={clsx(

--- a/src/lib/components/JobApplicationForm.svelte
+++ b/src/lib/components/JobApplicationForm.svelte
@@ -348,8 +348,7 @@
 					id="comments"
 					name="comments"
 					placeholder="Tell us about your experience, the type of role you're interested in, availability, etc."
-					rows={5}
-				></textarea>
+					rows={5}></textarea>
 			</div>
 
 			<div class="md:col-span-2">

--- a/src/lib/components/MeetTheTeam.svelte
+++ b/src/lib/components/MeetTheTeam.svelte
@@ -71,8 +71,8 @@
 			<enhanced:img
 				alt=""
 				class={clsx(
-				'aspect-square rounded-full object-cover outline-1 -outline-offset-1 outline-white/10',
-				featured ? 'mt-4 max-w-[200px] shadow-lg' : 'max-w-[144px]'
+					'aspect-square rounded-full object-cover outline-1 -outline-offset-1 outline-white/10',
+					featured ? 'mt-4 max-w-[200px] shadow-lg' : 'max-w-[144px]'
 				)}
 				loading="lazy"
 				src={teamMember.imageSrc}

--- a/src/lib/data/blogPosts.ts
+++ b/src/lib/data/blogPosts.ts
@@ -239,6 +239,197 @@ export const blogPosts: BlogPost[] = [
 				If any of the signs we've discussed resonate with your situation, it might be time to explore your options. The right partner won't just take work off your plate; they'll help you build a better equity program that serves your company and your people well.
 			</p>
 		`
+	},
+	{
+		slug: 'stock-plan-administration-guide',
+		title: 'Stock Plan Administration: What Companies Need to Manage',
+		metaTitle: 'Stock Plan Administration Guide | Accelerated Equity Plans',
+		metaDescription:
+			'Stock plan administration covers grants, vesting, exercises, releases, reporting, compliance, participant support, and equity platform workflows. Learn what strong administration requires.',
+		excerpt:
+			'Stock plan administration is the operating discipline behind equity compensation. This guide explains the workflows, controls, and support companies need to run stock plans accurately.',
+		publishedDate: '2026-06-29',
+		author: {
+			name: 'Emily Bone, MBA, CEP',
+			title: 'Founder & CEO'
+		},
+		category: 'Stock Plan Administration',
+		tags: [
+			'stock plan administration',
+			'equity administration',
+			'outsourced stock plan administration'
+		],
+		readingTime: 7,
+		content: `
+			<p class="lead">
+				Stock plan administration is the day-to-day work of running a company’s equity compensation program. It includes grant setup, vesting, exercises, releases, ESPP activity, participant support, compliance coordination, data reconciliation, and equity platform management. Strong administration protects the company from avoidable errors while giving employees a clearer experience with their equity awards.
+			</p>
+
+			<h2>What Stock Plan Administration Includes</h2>
+			<p>
+				Every company’s equity program is different, but the core administration work usually includes maintaining accurate participant and award data, processing grants and releases, reconciling transactions, supporting payroll and accounting teams, preparing reports, and answering employee questions. For public companies, administration also intersects with Section 16, proxy, audit, and insider reporting workflows.
+			</p>
+
+			<h2>Why Administration Gets Complex</h2>
+			<p>
+				Equity programs become harder to manage as headcount, award types, transaction volume, and compliance obligations increase. RSUs, options, ESPPs, PSUs, performance conditions, international mobility, and corporate transactions all add operational detail. A process that works for a small private company can break down quickly as the company scales or prepares for a liquidity event.
+			</p>
+
+			<h2>In-House, Co-Sourced, or Outsourced</h2>
+			<p>
+				Some companies keep stock plan administration fully in-house. Others use a co-sourced model where an outside specialist handles specific workflows, peak periods, or compliance-heavy tasks. Companies with limited internal capacity often choose <a href="/services/equity-plan-administration">outsourced stock plan administration</a> so experienced equity professionals can own the recurring work.
+			</p>
+
+			<h2>What Strong Administration Looks Like</h2>
+			<p>
+				Strong administration is accurate, documented, timely, and understandable. It includes clear ownership, documented controls, clean platform data, recurring reconciliation, and a reliable path for employee questions. It also connects smoothly with payroll, HR, legal, accounting, tax, treasury, and external vendors.
+			</p>
+
+			<h2>When to Bring in Help</h2>
+			<p>
+				Consider outside support when your equity workload is outpacing internal capacity, you are preparing for IPO or M&A activity, you need a temporary or fractional stock plan administrator, your platform data needs cleanup, or compliance deadlines are creating risk. A specialized partner can stabilize the program while helping the internal team focus on strategy.
+			</p>
+		`
+	},
+	{
+		slug: 'section-6039-reporting-guide',
+		title: 'Section 6039 Reporting for ISOs and ESPPs',
+		metaTitle: 'Section 6039 Reporting Guide | Accelerated Equity Plans',
+		metaDescription:
+			'Learn what Section 6039 reporting requires for ISO exercises and ESPP transfers, including Forms 3921 and 3922, participant statements, and filing support.',
+		excerpt:
+			'Section 6039 reporting is a recurring compliance obligation for companies with ISO and ESPP activity. Here is what it covers and how to reduce reporting risk.',
+		publishedDate: '2026-06-29',
+		author: {
+			name: 'Emily Bone, MBA, CEP',
+			title: 'Founder & CEO'
+		},
+		category: 'Compliance',
+		tags: ['6039 reporting', 'section 6039', 'Form 3921', 'Form 3922', 'ESPP administration'],
+		readingTime: 6,
+		content: `
+			<p class="lead">
+				Section 6039 reporting applies when companies have reportable incentive stock option exercises or employee stock purchase plan transfers. The process generally includes identifying reportable events, preparing participant statements, filing Forms 3921 or 3922, and reconciling the underlying transaction data before deadlines arrive.
+			</p>
+
+			<h2>What Section 6039 Covers</h2>
+			<p>
+				Companies typically use Form 3921 for incentive stock option exercises and Form 3922 for certain ESPP share transfers. The reporting process depends on accurate equity platform data, participant information, grant details, exercise or transfer dates, fair market value, purchase price, and other transaction fields.
+			</p>
+
+			<h2>Why Companies Struggle With 6039 Reporting</h2>
+			<p>
+				Errors often start with incomplete data, platform configuration issues, stale participant addresses, or unclear ownership between equity, payroll, tax, and legal teams. The work is also easy to underestimate because it may happen only once a year, even though the underlying transactions occur throughout the year.
+			</p>
+
+			<h2>How to Reduce Reporting Risk</h2>
+			<p>
+				Start early, reconcile transaction data, confirm participant details, document assumptions, and build a repeatable review process. Companies should also coordinate with tax advisors and equity platform vendors before filing. A clean process reduces last-minute corrections and helps employees receive accurate statements.
+			</p>
+
+			<h2>How AEP Supports Section 6039</h2>
+			<p>
+				Accelerated Equity Plans supports Section 6039 reporting as part of broader <a href="/services/equity-plan-administration">equity administration services</a>. We help reconcile data, coordinate reporting workflows, prepare participant statement processes, and support the operational work needed for accurate filing.
+			</p>
+		`
+	},
+	{
+		slug: 'equity-compensation-services',
+		title: 'Equity Compensation Services: What Companies Can Outsource',
+		metaTitle: 'Equity Compensation Services for Companies | Accelerated Equity Plans',
+		metaDescription:
+			'Equity compensation services can include stock plan administration, compliance support, employee education, platform implementation, process design, IPO readiness, and M&A support.',
+		excerpt:
+			'Equity compensation services give companies access to specialized support across administration, compliance, systems, employee education, and strategic equity projects.',
+		publishedDate: '2026-06-29',
+		author: {
+			name: 'Emily Bone, MBA, CEP',
+			title: 'Founder & CEO'
+		},
+		category: 'Equity Compensation',
+		tags: [
+			'equity compensation services',
+			'equity compensation consulting',
+			'equity compensation management'
+		],
+		readingTime: 7,
+		content: `
+			<p class="lead">
+				Equity compensation services help companies design, administer, and improve the programs they use to grant ownership or ownership-like incentives. Depending on the company’s needs, these services may include stock plan administration, compliance support, employee education, vendor implementation, process design, IPO readiness, or M&A support.
+			</p>
+
+			<h2>Administration Services</h2>
+			<p>
+				Administration services cover the recurring operational work: grants, vesting, exercises, releases, ESPP activity, participant support, reporting, reconciliation, and equity platform workflows. This is often the first area companies outsource when internal bandwidth is limited.
+			</p>
+
+			<h2>Compliance and Reporting Services</h2>
+			<p>
+				Equity compensation creates tax, accounting, securities, and employee reporting obligations. Companies may need support with Section 16 processes, Section 6039 reporting, ASC 718 coordination, proxy support, blackout processes, and audit requests.
+			</p>
+
+			<h2>Systems and Vendor Support</h2>
+			<p>
+				Most equity programs depend on a dedicated platform. <a href="/services/vendor-support">Vendor support</a> can include platform selection, implementation, data migration, configuration, integrations, testing, and optimization after go-live.
+			</p>
+
+			<h2>Strategic Consulting Services</h2>
+			<p>
+				Companies also need strategic help when designing equity programs, improving processes, preparing for IPO readiness, or managing equity treatment during M&A. These projects require both technical equity knowledge and practical operating experience.
+			</p>
+
+			<h2>Choosing the Right Support Model</h2>
+			<p>
+				The right support model depends on complexity, transaction volume, internal capacity, and upcoming company events. AEP offers flexible <a href="/services">equity plan services</a> so companies can choose fully outsourced administration, targeted project support, temporary coverage, or strategic consulting.
+			</p>
+		`
+	},
+	{
+		slug: 'choosing-equity-management-company',
+		title: 'How to Choose an Equity Management Company',
+		metaTitle: 'How to Choose an Equity Management Company | Accelerated Equity Plans',
+		metaDescription:
+			'Choosing an equity management company requires evaluating administration expertise, platform experience, compliance knowledge, service model, scalability, and communication.',
+		excerpt:
+			'The right equity management company should reduce risk, improve operations, and fit the way your internal teams work. Here is what to evaluate before choosing a partner.',
+		publishedDate: '2026-06-29',
+		author: {
+			name: 'Emily Bone, MBA, CEP',
+			title: 'Founder & CEO'
+		},
+		category: 'Equity Management',
+		tags: ['equity management company', 'equity management', 'equity administration outsourcing'],
+		readingTime: 6,
+		content: `
+			<p class="lead">
+				Choosing an equity management company is an operational decision as much as a consulting decision. The right partner should understand your equity plans, your platform, your compliance obligations, and the way your internal teams work. The goal is not just to move tasks off your plate, but to reduce risk and create a better participant experience.
+			</p>
+
+			<h2>Look for Hands-On Administration Experience</h2>
+			<p>
+				Equity management depends on execution. Ask whether the team has direct experience processing grants, managing vesting and releases, supporting ESPPs, reconciling data, coordinating filings, and answering participant questions. Strategy matters, but operational fluency is what prevents errors.
+			</p>
+
+			<h2>Evaluate Platform Knowledge</h2>
+			<p>
+				A strong partner should understand major equity platforms and how they connect with HR, payroll, accounting, and tax workflows. Platform expertise matters during implementation, migration, reporting, and ongoing data cleanup.
+			</p>
+
+			<h2>Confirm Compliance Depth</h2>
+			<p>
+				Equity programs touch SEC, tax, accounting, and plan-document requirements. Your partner should know how to support reporting calendars, audit requests, Section 6039, Section 16, ASC 718 coordination, and public-company controls.
+			</p>
+
+			<h2>Match the Service Model to Your Needs</h2>
+			<p>
+				Some companies need full outsourcing. Others need fractional coverage, temporary support, project help, or a strategic advisor for complex events. A flexible <a href="/services/equity-plan-administration">equity administration partner</a> can adapt as your company grows.
+			</p>
+
+			<h2>Prioritize Communication</h2>
+			<p>
+				Equity management involves HR, payroll, legal, finance, accounting, executives, vendors, and employees. Choose a partner who communicates clearly, documents decisions, and can operate as an extension of your team.
+			</p>
+		`
 	}
 ];
 

--- a/src/lib/data/blogPosts.ts
+++ b/src/lib/data/blogPosts.ts
@@ -245,9 +245,13 @@ export const blogPosts: BlogPost[] = [
 		title: 'Stock Plan Administration: What Companies Need to Manage',
 		metaTitle: 'Stock Plan Administration Guide | Accelerated Equity Plans',
 		metaDescription:
-			'Stock plan administration covers grants, vesting, exercises, releases, reporting, compliance, participant support, and equity platform workflows. Learn what strong administration requires.',
+			'Stock plan administration covers grants, vesting, exercises, releases, reporting, ' +
+			'compliance, participant support, and equity platform workflows. Learn what strong ' +
+			'administration requires.',
 		excerpt:
-			'Stock plan administration is the operating discipline behind equity compensation. This guide explains the workflows, controls, and support companies need to run stock plans accurately.',
+			'Stock plan administration is the operating discipline behind equity compensation. ' +
+			'This guide explains the workflows, controls, and support companies need to run stock ' +
+			'plans accurately.',
 		publishedDate: '2026-06-29',
 		author: {
 			name: 'Emily Bone, MBA, CEP',
@@ -262,32 +266,55 @@ export const blogPosts: BlogPost[] = [
 		readingTime: 7,
 		content: `
 			<p class="lead">
-				Stock plan administration is the day-to-day work of running a company’s equity compensation program. It includes grant setup, vesting, exercises, releases, ESPP activity, participant support, compliance coordination, data reconciliation, and equity platform management. Strong administration protects the company from avoidable errors while giving employees a clearer experience with their equity awards.
+				Stock plan administration is the day-to-day work of running a company’s equity
+				compensation program. It includes grant setup, vesting, exercises, releases, ESPP
+				activity, participant support, compliance coordination, data reconciliation, and equity
+				platform management. Strong administration protects the company from avoidable errors
+				while giving employees a clearer experience with their equity awards.
 			</p>
 
 			<h2>What Stock Plan Administration Includes</h2>
 			<p>
-				Every company’s equity program is different, but the core administration work usually includes maintaining accurate participant and award data, processing grants and releases, reconciling transactions, supporting payroll and accounting teams, preparing reports, and answering employee questions. For public companies, administration also intersects with Section 16, proxy, audit, and insider reporting workflows.
+				Every company’s equity program is different, but the core administration work usually
+				includes maintaining accurate participant and award data, processing grants and
+				releases, reconciling transactions, supporting payroll and accounting teams, preparing
+				reports, and answering employee questions. For public companies, administration also
+				intersects with Section 16, proxy, audit, and insider reporting workflows.
 			</p>
 
 			<h2>Why Administration Gets Complex</h2>
 			<p>
-				Equity programs become harder to manage as headcount, award types, transaction volume, and compliance obligations increase. RSUs, options, ESPPs, PSUs, performance conditions, international mobility, and corporate transactions all add operational detail. A process that works for a small private company can break down quickly as the company scales or prepares for a liquidity event.
+				Equity programs become harder to manage as headcount, award types, transaction volume,
+				and compliance obligations increase. RSUs, options, ESPPs, PSUs, performance
+				conditions, international mobility, and corporate transactions all add operational
+				detail. A process that works for a small private company can break down quickly as the
+				company scales or prepares for a liquidity event.
 			</p>
 
 			<h2>In-House, Co-Sourced, or Outsourced</h2>
 			<p>
-				Some companies keep stock plan administration fully in-house. Others use a co-sourced model where an outside specialist handles specific workflows, peak periods, or compliance-heavy tasks. Companies with limited internal capacity often choose <a href="/services/equity-plan-administration">outsourced stock plan administration</a> so experienced equity professionals can own the recurring work.
+				Some companies keep stock plan administration fully in-house. Others use a co-sourced
+				model where an outside specialist handles specific workflows, peak periods, or
+				compliance-heavy tasks. Companies with limited internal capacity often choose
+				<a href="/services/equity-plan-administration">outsourced stock plan administration</a>
+				so experienced equity professionals can own the recurring work.
 			</p>
 
 			<h2>What Strong Administration Looks Like</h2>
 			<p>
-				Strong administration is accurate, documented, timely, and understandable. It includes clear ownership, documented controls, clean platform data, recurring reconciliation, and a reliable path for employee questions. It also connects smoothly with payroll, HR, legal, accounting, tax, treasury, and external vendors.
+				Strong administration is accurate, documented, timely, and understandable. It includes
+				clear ownership, documented controls, clean platform data, recurring reconciliation,
+				and a reliable path for employee questions. It also connects smoothly with payroll, HR,
+				legal, accounting, tax, treasury, and external vendors.
 			</p>
 
 			<h2>When to Bring in Help</h2>
 			<p>
-				Consider outside support when your equity workload is outpacing internal capacity, you are preparing for IPO or M&A activity, you need a temporary or fractional stock plan administrator, your platform data needs cleanup, or compliance deadlines are creating risk. A specialized partner can stabilize the program while helping the internal team focus on strategy.
+				Consider outside support when your equity workload is outpacing internal capacity, you
+				are preparing for IPO or M&A activity, you need a temporary or fractional stock plan
+				administrator, your platform data needs cleanup, or compliance deadlines are creating
+				risk. A specialized partner can stabilize the program while helping the internal team
+				focus on strategy.
 			</p>
 		`
 	},
@@ -296,9 +323,11 @@ export const blogPosts: BlogPost[] = [
 		title: 'Section 6039 Reporting for ISOs and ESPPs',
 		metaTitle: 'Section 6039 Reporting Guide | Accelerated Equity Plans',
 		metaDescription:
-			'Learn what Section 6039 reporting requires for ISO exercises and ESPP transfers, including Forms 3921 and 3922, participant statements, and filing support.',
+			'Learn what Section 6039 reporting requires for ISO exercises and ESPP transfers, ' +
+			'including Forms 3921 and 3922, participant statements, and filing support.',
 		excerpt:
-			'Section 6039 reporting is a recurring compliance obligation for companies with ISO and ESPP activity. Here is what it covers and how to reduce reporting risk.',
+			'Section 6039 reporting is a recurring compliance obligation for companies with ISO ' +
+			'and ESPP activity. Here is what it covers and how to reduce reporting risk.',
 		publishedDate: '2026-06-29',
 		author: {
 			name: 'Emily Bone, MBA, CEP',
@@ -309,27 +338,42 @@ export const blogPosts: BlogPost[] = [
 		readingTime: 6,
 		content: `
 			<p class="lead">
-				Section 6039 reporting applies when companies have reportable incentive stock option exercises or employee stock purchase plan transfers. The process generally includes identifying reportable events, preparing participant statements, filing Forms 3921 or 3922, and reconciling the underlying transaction data before deadlines arrive.
+				Section 6039 reporting applies when companies have reportable incentive stock option
+				exercises or employee stock purchase plan transfers. The process generally includes
+				identifying reportable events, preparing participant statements, filing Forms 3921 or
+				3922, and reconciling the underlying transaction data before deadlines arrive.
 			</p>
 
 			<h2>What Section 6039 Covers</h2>
 			<p>
-				Companies typically use Form 3921 for incentive stock option exercises and Form 3922 for certain ESPP share transfers. The reporting process depends on accurate equity platform data, participant information, grant details, exercise or transfer dates, fair market value, purchase price, and other transaction fields.
+				Companies typically use Form 3921 for incentive stock option exercises and Form 3922
+				for certain ESPP share transfers. The reporting process depends on accurate equity
+				platform data, participant information, grant details, exercise or transfer dates,
+				fair market value, purchase price, and other transaction fields.
 			</p>
 
 			<h2>Why Companies Struggle With 6039 Reporting</h2>
 			<p>
-				Errors often start with incomplete data, platform configuration issues, stale participant addresses, or unclear ownership between equity, payroll, tax, and legal teams. The work is also easy to underestimate because it may happen only once a year, even though the underlying transactions occur throughout the year.
+				Errors often start with incomplete data, platform configuration issues, stale
+				participant addresses, or unclear ownership between equity, payroll, tax, and legal
+				teams. The work is also easy to underestimate because it may happen only once a year,
+				even though the underlying transactions occur throughout the year.
 			</p>
 
 			<h2>How to Reduce Reporting Risk</h2>
 			<p>
-				Start early, reconcile transaction data, confirm participant details, document assumptions, and build a repeatable review process. Companies should also coordinate with tax advisors and equity platform vendors before filing. A clean process reduces last-minute corrections and helps employees receive accurate statements.
+				Start early, reconcile transaction data, confirm participant details, document
+				assumptions, and build a repeatable review process. Companies should also coordinate
+				with tax advisors and equity platform vendors before filing. A clean process reduces
+				last-minute corrections and helps employees receive accurate statements.
 			</p>
 
 			<h2>How AEP Supports Section 6039</h2>
 			<p>
-				Accelerated Equity Plans supports Section 6039 reporting as part of broader <a href="/services/equity-plan-administration">equity administration services</a>. We help reconcile data, coordinate reporting workflows, prepare participant statement processes, and support the operational work needed for accurate filing.
+				Accelerated Equity Plans supports Section 6039 reporting as part of broader
+				<a href="/services/equity-plan-administration">equity administration services</a>. We
+				help reconcile data, coordinate reporting workflows, prepare participant statement
+				processes, and support the operational work needed for accurate filing.
 			</p>
 		`
 	},
@@ -338,9 +382,12 @@ export const blogPosts: BlogPost[] = [
 		title: 'Equity Compensation Services: What Companies Can Outsource',
 		metaTitle: 'Equity Compensation Services for Companies | Accelerated Equity Plans',
 		metaDescription:
-			'Equity compensation services can include stock plan administration, compliance support, employee education, platform implementation, process design, IPO readiness, and M&A support.',
+			'Equity compensation services can include stock plan administration, compliance ' +
+			'support, employee education, platform implementation, process design, IPO readiness, ' +
+			'and M&A support.',
 		excerpt:
-			'Equity compensation services give companies access to specialized support across administration, compliance, systems, employee education, and strategic equity projects.',
+			'Equity compensation services give companies access to specialized support across ' +
+			'administration, compliance, systems, employee education, and strategic equity projects.',
 		publishedDate: '2026-06-29',
 		author: {
 			name: 'Emily Bone, MBA, CEP',
@@ -355,32 +402,49 @@ export const blogPosts: BlogPost[] = [
 		readingTime: 7,
 		content: `
 			<p class="lead">
-				Equity compensation services help companies design, administer, and improve the programs they use to grant ownership or ownership-like incentives. Depending on the company’s needs, these services may include stock plan administration, compliance support, employee education, vendor implementation, process design, IPO readiness, or M&A support.
+				Equity compensation services help companies design, administer, and improve the
+				programs they use to grant ownership or ownership-like incentives. Depending on the
+				company’s needs, these services may include stock plan administration, compliance
+				support, employee education, vendor implementation, process design, IPO readiness, or
+				M&A support.
 			</p>
 
 			<h2>Administration Services</h2>
 			<p>
-				Administration services cover the recurring operational work: grants, vesting, exercises, releases, ESPP activity, participant support, reporting, reconciliation, and equity platform workflows. This is often the first area companies outsource when internal bandwidth is limited.
+				Administration services cover the recurring operational work: grants, vesting,
+				exercises, releases, ESPP activity, participant support, reporting, reconciliation,
+				and equity platform workflows. This is often the first area companies outsource when
+				internal bandwidth is limited.
 			</p>
 
 			<h2>Compliance and Reporting Services</h2>
 			<p>
-				Equity compensation creates tax, accounting, securities, and employee reporting obligations. Companies may need support with Section 16 processes, Section 6039 reporting, ASC 718 coordination, proxy support, blackout processes, and audit requests.
+				Equity compensation creates tax, accounting, securities, and employee reporting
+				obligations. Companies may need support with Section 16 processes, Section 6039
+				reporting, ASC 718 coordination, proxy support, blackout processes, and audit requests.
 			</p>
 
 			<h2>Systems and Vendor Support</h2>
 			<p>
-				Most equity programs depend on a dedicated platform. <a href="/services/vendor-support">Vendor support</a> can include platform selection, implementation, data migration, configuration, integrations, testing, and optimization after go-live.
+				Most equity programs depend on a dedicated platform.
+				<a href="/services/vendor-support">Vendor support</a> can include platform selection,
+				implementation, data migration, configuration, integrations, testing, and optimization
+				after go-live.
 			</p>
 
 			<h2>Strategic Consulting Services</h2>
 			<p>
-				Companies also need strategic help when designing equity programs, improving processes, preparing for IPO readiness, or managing equity treatment during M&A. These projects require both technical equity knowledge and practical operating experience.
+				Companies also need strategic help when designing equity programs, improving
+				processes, preparing for IPO readiness, or managing equity treatment during M&A. These
+				projects require both technical equity knowledge and practical operating experience.
 			</p>
 
 			<h2>Choosing the Right Support Model</h2>
 			<p>
-				The right support model depends on complexity, transaction volume, internal capacity, and upcoming company events. AEP offers flexible <a href="/services">equity plan services</a> so companies can choose fully outsourced administration, targeted project support, temporary coverage, or strategic consulting.
+				The right support model depends on complexity, transaction volume, internal capacity,
+				and upcoming company events. AEP offers flexible <a href="/services">equity plan
+				services</a> so companies can choose fully outsourced administration, targeted project
+				support, temporary coverage, or strategic consulting.
 			</p>
 		`
 	},
@@ -389,9 +453,11 @@ export const blogPosts: BlogPost[] = [
 		title: 'How to Choose an Equity Management Company',
 		metaTitle: 'How to Choose an Equity Management Company | Accelerated Equity Plans',
 		metaDescription:
-			'Choosing an equity management company requires evaluating administration expertise, platform experience, compliance knowledge, service model, scalability, and communication.',
+			'Choosing an equity management company requires evaluating administration expertise, ' +
+			'platform experience, compliance knowledge, service model, scalability, and communication.',
 		excerpt:
-			'The right equity management company should reduce risk, improve operations, and fit the way your internal teams work. Here is what to evaluate before choosing a partner.',
+			'The right equity management company should reduce risk, improve operations, and fit ' +
+			'the way your internal teams work. Here is what to evaluate before choosing a partner.',
 		publishedDate: '2026-06-29',
 		author: {
 			name: 'Emily Bone, MBA, CEP',
@@ -402,32 +468,48 @@ export const blogPosts: BlogPost[] = [
 		readingTime: 6,
 		content: `
 			<p class="lead">
-				Choosing an equity management company is an operational decision as much as a consulting decision. The right partner should understand your equity plans, your platform, your compliance obligations, and the way your internal teams work. The goal is not just to move tasks off your plate, but to reduce risk and create a better participant experience.
+				Choosing an equity management company is an operational decision as much as a
+				consulting decision. The right partner should understand your equity plans, your
+				platform, your compliance obligations, and the way your internal teams work. The goal
+				is not just to move tasks off your plate, but to reduce risk and create a better
+				participant experience.
 			</p>
 
 			<h2>Look for Hands-On Administration Experience</h2>
 			<p>
-				Equity management depends on execution. Ask whether the team has direct experience processing grants, managing vesting and releases, supporting ESPPs, reconciling data, coordinating filings, and answering participant questions. Strategy matters, but operational fluency is what prevents errors.
+				Equity management depends on execution. Ask whether the team has direct experience
+				processing grants, managing vesting and releases, supporting ESPPs, reconciling data,
+				coordinating filings, and answering participant questions. Strategy matters, but
+				operational fluency is what prevents errors.
 			</p>
 
 			<h2>Evaluate Platform Knowledge</h2>
 			<p>
-				A strong partner should understand major equity platforms and how they connect with HR, payroll, accounting, and tax workflows. Platform expertise matters during implementation, migration, reporting, and ongoing data cleanup.
+				A strong partner should understand major equity platforms and how they connect with HR,
+				payroll, accounting, and tax workflows. Platform expertise matters during
+				implementation, migration, reporting, and ongoing data cleanup.
 			</p>
 
 			<h2>Confirm Compliance Depth</h2>
 			<p>
-				Equity programs touch SEC, tax, accounting, and plan-document requirements. Your partner should know how to support reporting calendars, audit requests, Section 6039, Section 16, ASC 718 coordination, and public-company controls.
+				Equity programs touch SEC, tax, accounting, and plan-document requirements. Your
+				partner should know how to support reporting calendars, audit requests, Section 6039,
+				Section 16, ASC 718 coordination, and public-company controls.
 			</p>
 
 			<h2>Match the Service Model to Your Needs</h2>
 			<p>
-				Some companies need full outsourcing. Others need fractional coverage, temporary support, project help, or a strategic advisor for complex events. A flexible <a href="/services/equity-plan-administration">equity administration partner</a> can adapt as your company grows.
+				Some companies need full outsourcing. Others need fractional coverage, temporary
+				support, project help, or a strategic advisor for complex events. A flexible
+				<a href="/services/equity-plan-administration">equity administration partner</a> can
+				adapt as your company grows.
 			</p>
 
 			<h2>Prioritize Communication</h2>
 			<p>
-				Equity management involves HR, payroll, legal, finance, accounting, executives, vendors, and employees. Choose a partner who communicates clearly, documents decisions, and can operate as an extension of your team.
+				Equity management involves HR, payroll, legal, finance, accounting, executives,
+				vendors, and employees. Choose a partner who communicates clearly, documents
+				decisions, and can operate as an extension of your team.
 			</p>
 		`
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -519,27 +519,7 @@
 	const partytownScript = `<script>${partytownSnippet()}</${'script'}>`;
 
 	function jsonLDScript() {
-		const organizationSchema = {
-			'@context': 'https://schema.org',
-			'@type': 'Organization',
-			name: 'Accelerated Equity Plans',
-			url: 'https://www.acceleratedep.com',
-			description:
-				'Accelerated Equity Plans provides expert equity plan administration, consulting, and outsourcing services for private and public companies.',
-			logo: 'https://www.acceleratedep.com/images/brand/aep-logo.svg',
-			image: 'https://www.acceleratedep.com/images/og-image.jpg',
-			email: 'info@acceleratedep.com',
-			telephone: '+1-801-808-6238',
-			sameAs: ['https://www.linkedin.com/company/accelerated-equity-plans/'],
-			address: {
-				'@type': 'PostalAddress',
-				addressLocality: 'Salt Lake City',
-				addressRegion: 'UT',
-				addressCountry: 'US'
-			}
-		};
-
-		return `<script type="application/ld+json">${JSON.stringify(organizationSchema)}</${'script'}>`;
+		return `<script type="application/ld+json">${JSON.stringify(jsonLD())}</${'script'}>`;
 	}
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,7 +22,22 @@
 			link.setAttribute('rel', 'stylesheet');
 		});
 
-		// Lazy-load Zoho SalesIQ chat widget after page is interactive
+		const scheduleThirdPartyScript = (callback: () => void, timeout = 10000) => {
+			let loaded = false;
+			const load = () => {
+				if (loaded) return;
+				loaded = true;
+				callback();
+			};
+
+			['pointerdown', 'keydown', 'scroll'].forEach((eventName) => {
+				window.addEventListener(eventName, load, { once: true, passive: true });
+			});
+
+			setTimeout(load, timeout);
+		};
+
+		// Lazy-load Zoho SalesIQ chat widget after the initial page experience.
 		const loadZohoChat = () => {
 			const zohoGlobal =
 				typeof window.$zoho === 'object' && window.$zoho !== null
@@ -42,8 +57,7 @@
 			document.head.appendChild(script);
 		};
 
-		// Delay loading by 3 seconds to keep it off the critical path
-		setTimeout(loadZohoChat, 3000);
+		scheduleThirdPartyScript(loadZohoChat, 10000);
 
 		// Load PageSense after the page is idle to avoid render-blocking
 		const loadPageSense = () => {
@@ -54,11 +68,7 @@
 			document.head.appendChild(script);
 		};
 
-		if ('requestIdleCallback' in window) {
-			requestIdleCallback(loadPageSense);
-		} else {
-			setTimeout(loadPageSense, 3000);
-		}
+		scheduleThirdPartyScript(loadPageSense, 12000);
 	});
 
 	const navLinks: {
@@ -509,7 +519,27 @@
 	const partytownScript = `<script>${partytownSnippet()}</${'script'}>`;
 
 	function jsonLDScript() {
-		return `<script type="application/ld+json">${JSON.stringify(jsonLD())}</${'script'}>`;
+		const organizationSchema = {
+			'@context': 'https://schema.org',
+			'@type': 'Organization',
+			name: 'Accelerated Equity Plans',
+			url: 'https://www.acceleratedep.com',
+			description:
+				'Accelerated Equity Plans provides expert equity plan administration, consulting, and outsourcing services for private and public companies.',
+			logo: 'https://www.acceleratedep.com/images/brand/aep-logo.svg',
+			image: 'https://www.acceleratedep.com/images/og-image.jpg',
+			email: 'info@acceleratedep.com',
+			telephone: '+1-801-808-6238',
+			sameAs: ['https://www.linkedin.com/company/accelerated-equity-plans/'],
+			address: {
+				'@type': 'PostalAddress',
+				addressLocality: 'Salt Lake City',
+				addressRegion: 'UT',
+				addressCountry: 'US'
+			}
+		};
+
+		return `<script type="application/ld+json">${JSON.stringify(organizationSchema)}</${'script'}>`;
 	}
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -181,10 +181,8 @@
 		<!-- Should be foreground div in same container -->
 		<div class="relative z-10 h-full sm:px-8">
 			<div class="grid gap-2 max-w-3xl">
-				<h1 class={clsx(styles.h1Super, 'max-w-[13ch] leading-[0.95] lg:text-7xl xl:text-8xl')}>
-					<span class="block">Equity Management</span>
-					<span class="block">& Stock Plan</span>
-					<span class="block">Administration</span>
+				<h1 class={clsx(styles.h1Super, 'max-w-[16ch] leading-[0.95] lg:text-7xl xl:text-8xl')}>
+					Equity Management & Stock Plan Administration
 				</h1>
 				<p class="mt-6 text-lg font-light leading-8 max-w-[48ch] text-pretty">
 					Accelerated Equity Plans is an equity management company helping private and public

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -174,7 +174,7 @@
 					Equity management company for private and public organizations
 				</p>
 				<h1 class={clsx(styles.h1Super, 'max-w-[18ch] lg:text-7xl xl:text-8xl')}>
-					Equity Management & Stock Plan Administration
+					Accelerate Your Equity's Potential
 				</h1>
 				<div class="grid max-w-[58ch] gap-4 text-lg/8 font-light text-white/90 text-pretty">
 					<p>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -181,7 +181,11 @@
 		<!-- Should be foreground div in same container -->
 		<div class="relative z-10 h-full sm:px-8">
 			<div class="grid gap-2 max-w-3xl">
-				<h1 class={styles.h1Super}>Equity Management & Stock Plan Administration</h1>
+				<h1 class={clsx(styles.h1Super, 'max-w-[13ch] leading-[0.95] lg:text-7xl xl:text-8xl')}>
+					<span class="block">Equity Management</span>
+					<span class="block">& Stock Plan</span>
+					<span class="block">Administration</span>
+				</h1>
 				<p class="mt-6 text-lg font-light leading-8 max-w-[48ch] text-pretty">
 					Accelerated Equity Plans is an equity management company helping private and public
 					organizations run compliant, efficient equity compensation programs.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -148,6 +148,7 @@
 					class="block object-cover lg:hidden size-full"
 					fetchpriority="high"
 					src={HeroBgMobile}
+					sizes="100vw"
 				/>
 			{:else}
 				<enhanced:img
@@ -155,6 +156,7 @@
 					class="object-cover size-full"
 					fetchpriority="high"
 					src={HeroBg}
+					sizes="100vw"
 				/>
 			{/if}
 		</div>
@@ -179,10 +181,10 @@
 		<!-- Should be foreground div in same container -->
 		<div class="relative z-10 h-full sm:px-8">
 			<div class="grid gap-2 max-w-3xl">
-				<h1 class={styles.h1Super}>Accelerate Your <wbr />Equity's Potential</h1>
+				<h1 class={styles.h1Super}>Equity Management & Stock Plan Administration</h1>
 				<p class="mt-6 text-lg font-light leading-8 max-w-[48ch] text-pretty">
-					Bringing industry-leading expertise and support to your equity programs to deliver a
-					best-in-class experience for your team, partners, and participants.
+					Accelerated Equity Plans is an equity management company helping private and public
+					organizations run compliant, efficient equity compensation programs.
 				</p>
 				<p class="mt-2 text-lg font-light leading-8 max-w-[48ch] text-pretty">
 					Founded by industry experts with issuer and vendor experience for both private and public
@@ -219,17 +221,17 @@
 				</p>
 			</div>
 
-			<dl class="grid gap-6 mx-auto mt-12 max-w-7xl md:grid-cols-3">
+			<div class="grid gap-6 mx-auto mt-12 max-w-7xl md:grid-cols-3">
 				{#each servicesBoxes as servicesBox (servicesBox.title)}
-					<div class="flex flex-col gap-4 p-8 bg-white rounded-xl ring-1 ring-zinc-900/10">
+					<article class="flex flex-col gap-4 p-8 bg-white rounded-xl ring-1 ring-zinc-900/10">
 						<svelte:component this={servicesBox.icon} class="size-8 text-aep-red-700 shrink-0" />
-						<dt class={styles.h3}>{servicesBox.title}</dt>
-						<dd class="font-light text-zinc-600 prose prose-zinc max-w-none">
+						<h3 class={styles.h3}>{servicesBox.title}</h3>
+						<div class="font-light text-zinc-600 prose prose-zinc max-w-none">
 							{@html servicesBox.body}
-						</dd>
-					</div>
+						</div>
+					</article>
 				{/each}
-			</dl>
+			</div>
 		</div>
 		<div class="relative flex mt-10 mx-auto max-w-7xl">
 			<a href={resolve('/services')} class={styles.lightButton}>Explore All Equity Plan Services</a>
@@ -254,21 +256,21 @@
 			</div>
 		</div>
 
-		<dl class="relative grid gap-6 mx-auto mt-12 max-w-7xl sm:grid-cols-2">
+		<div class="relative grid gap-6 mx-auto mt-12 max-w-7xl sm:grid-cols-2">
 			{#each comprehensiveServices as comprehensiveService (comprehensiveService.title)}
-				<div class={clsx(styles.blueRedGradientBackground, 'bg-black/80 p-8')}>
+				<article class={clsx(styles.blueRedGradientBackground, 'bg-black/80 p-8')}>
 					<div class="flex gap-4 items-start">
 						<svelte:component
 							this={comprehensiveService.icon}
 							class={clsx('size-6 shrink-0', comprehensiveService.iconColor)}
 						/>
-						<dt class={clsx(styles.h3, 'text-white')}>
+						<h3 class={clsx(styles.h3, 'text-white')}>
 							<a class="hover:text-aep-red-300" href={resolve(comprehensiveService.detailsLink)}>
 								{comprehensiveService.title}
 							</a>
-						</dt>
+						</h3>
 					</div>
-					<dd>
+					<div>
 						<div class="font-light text-white prose prose-invert max-w-none">
 							{@html comprehensiveService.body}
 						</div>
@@ -292,10 +294,10 @@
 								Explore {comprehensiveService.title} Services
 							</a>
 						</div>
-					</dd>
-				</div>
+					</div>
+				</article>
 			{/each}
-		</dl>
+		</div>
 
 		<div class="relative flex justify-center mt-12">
 			<a href={resolve('/services')} class={styles.darkButton}>View All Services</a>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
 	import { resolve } from '$app/paths';
 	import type { Pathname } from '$app/types';
 	import CustomerReviews from '$lib/components/CustomerReviews.svelte';
@@ -12,6 +11,7 @@
 	import HeroBg from '$lib/images/backgrounds/high-rise-buildings.jpg?enhanced';
 	import { styles } from '$lib/styles';
 	import {
+		ArrowRight,
 		Building2,
 		DraftingCompass,
 		EarthIcon,
@@ -22,20 +22,10 @@
 	} from '@lucide/svelte';
 	import { clsx } from 'clsx';
 
-	let isMobile = true;
-
 	const title = 'Equity Management Company & Compensation Consulting | Accelerated Equity Plans';
 	const description =
 		'A dedicated equity management company offering expert equity compensation consulting, stock plan administration, and tailored solutions to unlock the full potential of your equity programs.';
 	const path = '/';
-
-	const updateWindowSize = () => {
-		isMobile = window.innerWidth < 768;
-	};
-	if (browser) {
-		updateWindowSize();
-		window.onresize = updateWindowSize;
-	}
 
 	const servicesBoxes = [
 		{
@@ -139,38 +129,38 @@
 
 <main class="bg-white isolate antialiased">
 	<!--  Hero Div -->
-	<section class={clsx(styles.heroSection, 'overflow-x-hidden', 'lg:px-28')}>
+	<section class={clsx(styles.heroSection, 'overflow-x-hidden', 'md:min-h-[86svh] lg:px-28')}>
 		<!-- Background Div -->
 		<div class="overflow-hidden absolute inset-0">
-			{#if isMobile}
-				<enhanced:img
-					alt="High-rise office buildings representing equity management and stock plan administration"
-					class="block object-cover lg:hidden size-full"
-					fetchpriority="high"
-					src={HeroBgMobile}
-					sizes="100vw"
-				/>
-			{:else}
-				<enhanced:img
-					alt="High-rise office buildings representing equity management and stock plan administration"
-					class="object-cover size-full"
-					fetchpriority="high"
-					src={HeroBg}
-					sizes="100vw"
-				/>
-			{/if}
+			<enhanced:img
+				alt="High-rise office buildings representing equity management and stock plan administration"
+				class="object-cover size-full md:hidden"
+				fetchpriority="high"
+				src={HeroBgMobile}
+				sizes="100vw"
+			/>
+			<enhanced:img
+				alt="High-rise office buildings representing equity management and stock plan administration"
+				class="hidden object-cover size-full md:block"
+				fetchpriority="high"
+				src={HeroBg}
+				sizes="100vw"
+			/>
 		</div>
 
 		<div
-			class="absolute inset-0 bg-linear-to-r from-black/90 via-black/80 to-black/70 lg:from-black/80 lg:via-black/70 lg:to-black/50"
+			class="absolute inset-0 bg-linear-to-r from-black/80 via-black/65 to-black/50 lg:from-black/82 lg:via-black/55 lg:to-black/20"
 		></div>
 		<div
-			class="w-[31vw] absolute bottom-0 left-[69vw] overflow-hidden opacity-50 md:bottom-[5%] md:opacity-100"
+			class="absolute inset-x-0 bottom-0 h-1/3 bg-linear-to-t from-black/70 to-transparent"
+		></div>
+		<div
+			class="pointer-events-none absolute right-[-8vw] bottom-[-8%] hidden w-[42vw] max-w-3xl opacity-55 lg:block"
 		>
 			<img
 				alt=""
 				aria-hidden="true"
-				class="max-w-none opacity-90 w-[50vw]"
+				class="w-full max-w-none"
 				height="150"
 				loading="lazy"
 				src="/images/brand/aep-mark-white.svg"
@@ -178,23 +168,40 @@
 			/>
 		</div>
 
-		<!-- Should be foreground div in same container -->
-		<div class="relative z-10 h-full sm:px-8">
-			<div class="grid gap-2 max-w-3xl">
-				<h1 class={clsx(styles.h1Super, 'max-w-[16ch] leading-[0.95] lg:text-7xl xl:text-8xl')}>
+		<div class="relative z-10 w-full sm:px-8">
+			<div class="grid max-w-5xl gap-6">
+				<p class="max-w-[48ch] text-base font-medium text-aep-red-100 text-pretty sm:text-lg">
+					Equity management company for private and public organizations
+				</p>
+				<h1 class={clsx(styles.h1Super, 'max-w-[18ch] lg:text-7xl xl:text-8xl')}>
 					Equity Management & Stock Plan Administration
 				</h1>
-				<p class="mt-6 text-lg font-light leading-8 max-w-[48ch] text-pretty">
-					Accelerated Equity Plans is an equity management company helping private and public
-					organizations run compliant, efficient equity compensation programs.
-				</p>
-				<p class="mt-2 text-lg font-light leading-8 max-w-[48ch] text-pretty">
-					Founded by industry experts with issuer and vendor experience for both private and public
-					organizations, we can handle all of your equity administration needs.
-				</p>
-				<div class="flex gap-x-4 mt-8">
-					<a href={resolve('/contact')} class={styles.redButton}>Contact us today</a>
+				<div class="grid max-w-[58ch] gap-4 text-lg/8 font-light text-white/90 text-pretty">
+					<p>
+						Accelerated Equity Plans helps companies run compliant, efficient equity compensation
+						programs with senior support across administration, systems, reporting, and strategic
+						transactions.
+					</p>
+					<p>
+						Founded by industry experts with issuer and vendor experience, we can handle all of your
+						equity administration needs.
+					</p>
 				</div>
+				<div class="flex flex-col gap-3 pt-2 sm:flex-row">
+					<a href={resolve('/contact')} class={styles.redButton}>Contact us today</a>
+					<a href={resolve('/services')} class={clsx(styles.darkButton, 'gap-2')}>
+						Explore services
+						<ArrowRight class="size-4 shrink-0" aria-hidden="true" />
+					</a>
+				</div>
+				<ul
+					role="list"
+					class="grid max-w-4xl gap-3 pt-6 text-base text-white/75 sm:grid-cols-3 sm:text-sm"
+				>
+					<li class="border-l border-white/20 pl-4">Stock plan administration</li>
+					<li class="border-l border-white/20 pl-4">Equity platform support</li>
+					<li class="border-l border-white/20 pl-4">IPO, M&A, and compliance projects</li>
+				</ul>
 			</div>
 		</div>
 	</section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -132,20 +132,22 @@
 	<section class={clsx(styles.heroSection, 'overflow-x-clip', 'md:min-h-[86svh] lg:px-28')}>
 		<!-- Background Div -->
 		<div class="overflow-hidden absolute inset-0">
-			<enhanced:img
-				alt="High-rise office buildings representing equity management and stock plan administration"
-				class="object-cover size-full md:hidden"
-				fetchpriority="high"
-				src={HeroBgMobile}
-				sizes="100vw"
-			/>
-			<enhanced:img
-				alt="High-rise office buildings representing equity management and stock plan administration"
-				class="hidden object-cover size-full md:block"
-				fetchpriority="high"
-				src={HeroBg}
-				sizes="100vw"
-			/>
+			<picture class="block size-full">
+				{#each Object.entries(HeroBg.sources) as [format, srcset]}
+					<source {srcset} media="(min-width: 768px)" sizes="100vw" type={`image/${format}`} />
+				{/each}
+				{#each Object.entries(HeroBgMobile.sources) as [format, srcset]}
+					<source {srcset} media="(max-width: 767px)" sizes="100vw" type={`image/${format}`} />
+				{/each}
+				<img
+					alt="High-rise office buildings representing equity management and stock plan administration"
+					class="object-cover size-full"
+					fetchpriority="high"
+					height={HeroBgMobile.img.h}
+					src={HeroBgMobile.img.src}
+					width={HeroBgMobile.img.w}
+				/>
+			</picture>
 		</div>
 
 		<div

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -129,7 +129,7 @@
 
 <main class="bg-white isolate antialiased">
 	<!--  Hero Div -->
-	<section class={clsx(styles.heroSection, 'overflow-x-hidden', 'md:min-h-[86svh] lg:px-28')}>
+	<section class={clsx(styles.heroSection, 'overflow-x-clip', 'md:min-h-[86svh] lg:px-28')}>
 		<!-- Background Div -->
 		<div class="overflow-hidden absolute inset-0">
 			<enhanced:img

--- a/src/routes/careers/+page.svelte
+++ b/src/routes/careers/+page.svelte
@@ -99,9 +99,9 @@
 
 	const faqs = [
 		{
-			question: 'What is equity plan administration?',
+			question: 'What does an equity plan administration career involve?',
 			answer:
-				"<p>Equity plan administration involves managing all aspects of a company's stock compensation programs. This includes processing stock option grants, managing RSU vesting schedules, handling ESPP enrollments and purchases, ensuring regulatory compliance, and supporting employees with their equity awards. It's a specialized field that combines finance, HR, legal, and technology expertise.</p>"
+				'<p>A career in equity plan administration involves supporting company stock compensation programs through transaction processing, data reconciliation, participant support, reporting coordination, and platform administration. If your company is looking for equity administration support rather than a job, visit our <a href="/services/equity-plan-administration">equity plan administration services</a> page.</p>'
 		},
 		{
 			question: 'What qualifications do I need for an equity plan administration job?',
@@ -141,29 +141,47 @@
 	];
 
 	function jsonLDScript() {
-		return `<script type="application/ld+json">${JSON.stringify(generateJobPostingSchema())}</${'script'}>`;
+		return `<script type="application/ld+json">${JSON.stringify(generateCareersSchema())}</${'script'}>`;
 	}
 
-	function generateJobPostingSchema() {
+	function generateCareersSchema() {
 		return {
 			'@context': 'https://schema.org',
-			'@type': 'Organization',
-			name: 'Accelerated Equity Plans',
-			url: 'https://www.acceleratedep.com',
-			description:
-				'Accelerated Equity Plans provides specialized equity plan administration services and employs equity compensation professionals across the United States.',
-			sameAs: ['https://www.linkedin.com/company/accelerated-equity-plans/'],
-			jobPostingAvailable: true,
-			knowsAbout: [
-				'Equity Plan Administration',
-				'Stock Compensation',
-				'RSU Administration',
-				'Stock Option Management',
-				'ESPP Administration',
-				'SEC Compliance',
-				'ASC 718 Reporting'
-			]
+			'@type': 'WebPage',
+			name: 'Equity Plan Administration Jobs & Careers',
+			url: 'https://www.acceleratedep.com/careers',
+			description,
+			about: {
+				'@type': 'Thing',
+				name: 'Equity plan administration careers'
+			},
+			isPartOf: {
+				'@type': 'WebSite',
+				name: 'Accelerated Equity Plans',
+				url: 'https://www.acceleratedep.com'
+			},
+			publisher: {
+				'@type': 'Organization',
+				name: 'Accelerated Equity Plans',
+				url: 'https://www.acceleratedep.com'
+			}
 		};
+	}
+
+	function loadJobListingWidget() {
+		if (document.getElementById('joblisting-widget-script')) return;
+
+		const script = document.createElement('script');
+		script.id = 'joblisting-widget-script';
+		script.src = 'https://joblisting.app/widget.js';
+		script.async = true;
+		script.defer = true;
+		document.head.appendChild(script);
+	}
+
+	function openApplyModal() {
+		applyModalOpen = true;
+		loadJobListingWidget();
 	}
 </script>
 
@@ -176,7 +194,6 @@
 	<link rel="canonical" href={`https://www.acceleratedep.com${path}`} />
 	<meta property="og:url" content={`https://www.acceleratedep.com${path}`} />
 	{@html jsonLDScript()}
-	<script src="https://joblisting.app/widget.js" defer async></script>
 </svelte:head>
 
 <main>
@@ -223,9 +240,7 @@
 					professionals to join our team.
 				</p>
 				<div class="mt-2">
-					<button onclick={() => (applyModalOpen = true)} class={styles.redButton}
-						>Join the AEP Team!</button
-					>
+					<button onclick={openApplyModal} class={styles.redButton}>Join the AEP Team!</button>
 				</div>
 			</div>
 		</div>

--- a/src/routes/careers/+page.svelte
+++ b/src/routes/careers/+page.svelte
@@ -101,7 +101,12 @@
 		{
 			question: 'What does an equity plan administration career involve?',
 			answer:
-				'<p>A career in equity plan administration involves supporting company stock compensation programs through transaction processing, data reconciliation, participant support, reporting coordination, and platform administration. If your company is looking for equity administration support rather than a job, visit our <a href="/services/equity-plan-administration">equity plan administration services</a> page.</p>'
+				'<p>A career in equity plan administration involves supporting company stock ' +
+				'compensation programs through transaction processing, data reconciliation, ' +
+				'participant support, reporting coordination, and platform administration. If your ' +
+				'company is looking for equity administration support rather than a job, visit our ' +
+				'<a href="/services/equity-plan-administration">equity plan administration services</a> ' +
+				'page.</p>'
 		},
 		{
 			question: 'What qualifications do I need for an equity plan administration job?',
@@ -141,7 +146,9 @@
 	];
 
 	function jsonLDScript() {
-		return `<script type="application/ld+json">${JSON.stringify(generateCareersSchema())}</${'script'}>`;
+		const schema = JSON.stringify(generateCareersSchema());
+
+		return `<script type="application/ld+json">${schema}</${'script'}>`;
 	}
 
 	function generateCareersSchema() {
@@ -176,6 +183,9 @@
 		script.src = 'https://joblisting.app/widget.js';
 		script.async = true;
 		script.defer = true;
+		script.onerror = () => {
+			script.remove();
+		};
 		document.head.appendChild(script);
 	}
 

--- a/src/routes/services/+page.svelte
+++ b/src/routes/services/+page.svelte
@@ -159,52 +159,64 @@
 
 	const moreServices = [
 		{
+			id: 'ipos-and-spacs',
 			title: `IPOs and SPACs`,
 			body: `We provide expert support throughout the IPO process, guiding companies through the complexities and challenges of going public to ensure a successful transition. We can also be a resource as work volumes pick up and you need extra support.`
 		},
 		{
+			id: 'corporate-actions',
 			title: `Corporate Actions`,
 			body: `We help companies navigate strategic restructuring through mergers & acquisitions, stock splits, and spinoffs.`
 		},
 		{
+			id: 'automation-design-and-resources',
 			title: `Automation Design and Resources`,
 			body: `Our Automation Design and Resources empower organizations to streamline processes and boost productivity. We integrate your equity systems with payroll and HRIS for seamless data flow and reduced risk, driving both efficiency and innovation.`
 		},
 		{
+			id: 'tax-and-mobility-implementation-and-support',
 			title: `Tax and Mobility implementation and support`,
 			body: `We ensure you're maximizing tax efficiency with a review of your withholding setup and best practice advice. Plus, we offer support throughout your mobility process, from initial setup and testing to ongoing assistance.`
 		},
 
 		{
+			id: 'system-implementation',
 			title: `System implementation`,
 			body: `We streamline your equity management by supporting implementation of new systems, data conversion (spreadsheets or legacy systems), and ensuring data reconciliation for accurate financial reporting.`
 		},
 		{
+			id: 'vendor-selection-and-rfp',
 			title: `Vendor Selection and RFP`,
 			body: `We provide expert vendor selection support, guiding businesses through the process of identifying and choosing the right partners to meet their specific needs and goals`
 		},
 		{
+			id: 'system-functionality-incorporation-and-testing',
 			title: `System functionality incorporation and testing`,
 			body: `We maximize your equity system's value by supporting implementation, testing, and automation, freeing you for strategic initiatives.`
 		},
 		{
+			id: 'process-review-and-documentation',
 			title: `Process review and documentation`,
 			body: `We review and document your current processes, interview stakeholders and recommend best practices`
 		},
 
 		{
+			id: 'training',
 			title: `Training`,
 			body: `AEP helps to train your employees on administering your equity plans, best practices and creating processes that will save time and reduce risk.`
 		},
 		{
+			id: 'education',
 			title: `Education`,
 			body: `We specialize in educating employees on their equity awards, providing comprehensive guidance and resources to ensure they understand the value and implications of their stock compensation plans.`
 		},
 		{
+			id: 'system-functionality-incorporation-and-testing-secondary',
 			title: `System functionality incorporation and testing`,
 			body: `We maximize your equity system's value by supporting implementation, testing, and automation, freeing you for strategic initiatives.`
 		},
 		{
+			id: 'process-review-and-documentation-secondary',
 			title: `Process review and documentation`,
 			body: `We review and document your current processes, interview stakeholders and recommend best practices`
 		}
@@ -352,7 +364,7 @@
 			</div>
 
 			<div class="grid gap-6 mx-auto mt-12 max-w-7xl md:grid-cols-2 xl:grid-cols-4">
-				{#each moreServices as service (service.title)}
+				{#each moreServices as service (service.id)}
 					<div class={clsx(styles.blueRedGradientBackground, styles.cardHover)}>
 						<div class="flex flex-col gap-4 justify-start p-8 h-full bg-black rounded-lg">
 							<h3 class={styles.h3}>

--- a/src/routes/services/equity-plan-administration/+page.svelte
+++ b/src/routes/services/equity-plan-administration/+page.svelte
@@ -130,14 +130,13 @@
 		return {
 			'@context': 'https://schema.org',
 			'@type': 'Service',
-			name: 'Equity Plan Administration',
+			name: 'Stock Plan Administration & Equity Administration Services',
 			provider: {
 				'@type': 'Organization',
 				name: 'Accelerated Equity Plans',
 				url: 'https://www.acceleratedep.com'
 			},
-			description:
-				'Specialized equity plan administration services including comprehensive equity management, employee education, outsourced administration, and scalable support solutions.',
+			description,
 			areaServed: 'United States',
 			serviceType: 'Equity Plan Administration',
 			hasOfferCatalog: {

--- a/src/routes/services/equity-plan-administration/+page.svelte
+++ b/src/routes/services/equity-plan-administration/+page.svelte
@@ -13,9 +13,10 @@
 	import { styles } from '$lib/styles';
 	import { clsx } from 'clsx';
 
-	const title = 'Stock Plan & Equity Plan Administration Services | Accelerated Equity Plans';
+	const title =
+		'Stock Plan Administration & Equity Administration Services | Accelerated Equity Plans';
 	const description =
-		'Outsourced stock plan administration and equity plan administration services—comprehensive equity management, employee education, and interim, fractional, and on-demand support for private and public companies.';
+		'Outsourced stock plan administration and equity administration services for private and public companies, including compliance, employee support, and flexible coverage.';
 	const path = '/services/equity-plan-administration';
 
 	const features = [
@@ -203,7 +204,7 @@
 		<div class="mx-auto max-w-7xl">
 			<div class="grid gap-8 mb-16">
 				<RedBar />
-				<h2 class={styles.h2}>Comprehensive Stock Plan & Equity Plan Administration</h2>
+				<h2 class={styles.h2}>Comprehensive Stock Plan Administration for Growing Companies</h2>
 				<div class="prose max-w-4xl text-lg text-stone-700 font-light">
 					<p>
 						Managing stock plan administration has become increasingly complex. Between evolving
@@ -225,6 +226,50 @@
 						platforms. We design streamlined processes that reduce manual work and minimize errors.
 						And we work collaboratively with your team, adapting our services to complement your
 						organization's unique structure and culture.
+					</p>
+					<p>
+						If you are evaluating whether to keep equity administration in-house or partner with an
+						equity management company, our team can support the operating model that fits your
+						business: fully outsourced administration, co-sourced support, temporary coverage, or
+						project-based help during reporting cycles and strategic transactions.
+					</p>
+				</div>
+			</div>
+
+			<div class="grid gap-8 mt-20">
+				<RedBar />
+				<h2 class={styles.h2}>What Our Equity Administration Team Handles</h2>
+				<div class="grid gap-6 md:grid-cols-3">
+					<div class="rounded-lg border border-stone-200 bg-stone-50 p-6">
+						<h3 class={clsx(styles.h4, 'mb-3 text-stone-900')}>Day-to-Day Stock Plan Operations</h3>
+						<p class="font-light leading-relaxed text-stone-700">
+							Grant processing, vesting events, exercises, releases, ESPP activity, data
+							reconciliation, participant support, and recurring administration workflows.
+						</p>
+					</div>
+					<div class="rounded-lg border border-stone-200 bg-stone-50 p-6">
+						<h3 class={clsx(styles.h4, 'mb-3 text-stone-900')}>Reporting & Compliance Support</h3>
+						<p class="font-light leading-relaxed text-stone-700">
+							Section 16, ASC 718 coordination, proxy and audit support, Section 6039 reporting,
+							participant statements, and controls that reduce filing and data risk.
+						</p>
+					</div>
+					<div class="rounded-lg border border-stone-200 bg-stone-50 p-6">
+						<h3 class={clsx(styles.h4, 'mb-3 text-stone-900')}>Flexible Administration Coverage</h3>
+						<p class="font-light leading-relaxed text-stone-700">
+							Interim, fractional, outsourced, and on-demand stock plan administrator support when
+							your team needs specialist capacity without adding a full-time hire.
+						</p>
+					</div>
+				</div>
+				<div class="prose max-w-4xl text-lg text-stone-700 font-light">
+					<p>
+						For additional context, read our guides to
+						<a href={resolve('/blog/stock-plan-administration-guide')}>stock plan administration</a
+						>,
+						<a href={resolve('/blog/section-6039-reporting-guide')}>Section 6039 reporting</a>, and
+						<a href={resolve('/blog/equity-compensation-services')}>equity compensation services</a
+						>.
 					</p>
 				</div>
 			</div>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -2,19 +2,38 @@ import { getPublishedBlogPosts } from '$lib/data/blogPosts';
 
 export async function GET() {
 	const baseUrl = 'https://www.acceleratedep.com';
-	const now = new Date().toISOString();
 
 	const pages = [
-		{ path: '/', priority: '1.0', changefreq: 'weekly' },
-		{ path: '/services', priority: '0.9', changefreq: 'monthly' },
-		{ path: '/services/equity-plan-administration', priority: '0.9', changefreq: 'monthly' },
-		{ path: '/services/vendor-support', priority: '0.9', changefreq: 'monthly' },
-		{ path: '/services/advanced-project-support', priority: '0.9', changefreq: 'monthly' },
-		{ path: '/services/plan-process-design', priority: '0.9', changefreq: 'monthly' },
-		{ path: '/about', priority: '0.8', changefreq: 'monthly' },
-		{ path: '/careers', priority: '0.7', changefreq: 'monthly' },
-		{ path: '/contact', priority: '0.7', changefreq: 'monthly' },
-		{ path: '/blog', priority: '0.8', changefreq: 'weekly' }
+		{ path: '/', priority: '1.0', changefreq: 'weekly', lastmod: '2026-06-29' },
+		{ path: '/services', priority: '0.9', changefreq: 'monthly', lastmod: '2026-06-29' },
+		{
+			path: '/services/equity-plan-administration',
+			priority: '0.9',
+			changefreq: 'monthly',
+			lastmod: '2026-06-29'
+		},
+		{
+			path: '/services/vendor-support',
+			priority: '0.9',
+			changefreq: 'monthly',
+			lastmod: '2026-06-29'
+		},
+		{
+			path: '/services/advanced-project-support',
+			priority: '0.9',
+			changefreq: 'monthly',
+			lastmod: '2026-06-29'
+		},
+		{
+			path: '/services/plan-process-design',
+			priority: '0.9',
+			changefreq: 'monthly',
+			lastmod: '2026-06-29'
+		},
+		{ path: '/about', priority: '0.8', changefreq: 'monthly', lastmod: '2026-06-29' },
+		{ path: '/careers', priority: '0.7', changefreq: 'monthly', lastmod: '2026-06-29' },
+		{ path: '/contact', priority: '0.7', changefreq: 'monthly', lastmod: '2026-06-29' },
+		{ path: '/blog', priority: '0.8', changefreq: 'weekly', lastmod: '2026-06-29' }
 	];
 
 	const blogPosts = getPublishedBlogPosts().map((post) => ({
@@ -33,7 +52,7 @@ ${pages
 	.map(
 		(page) => `  <url>
     <loc>${baseUrl}${page.path}</loc>
-    <lastmod>${now}</lastmod>
+    <lastmod>${page.lastmod}</lastmod>
     <priority>${page.priority}</priority>
     <changefreq>${page.changefreq}</changefreq>
   </url>`

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -16,23 +16,23 @@ export async function GET() {
 			path: '/services/vendor-support',
 			priority: '0.9',
 			changefreq: 'monthly',
-			lastmod: '2026-06-29'
+			lastmod: '2026-06-12'
 		},
 		{
 			path: '/services/advanced-project-support',
 			priority: '0.9',
 			changefreq: 'monthly',
-			lastmod: '2026-06-29'
+			lastmod: '2026-06-12'
 		},
 		{
 			path: '/services/plan-process-design',
 			priority: '0.9',
 			changefreq: 'monthly',
-			lastmod: '2026-06-29'
+			lastmod: '2026-04-21'
 		},
-		{ path: '/about', priority: '0.8', changefreq: 'monthly', lastmod: '2026-06-29' },
+		{ path: '/about', priority: '0.8', changefreq: 'monthly', lastmod: '2026-04-20' },
 		{ path: '/careers', priority: '0.7', changefreq: 'monthly', lastmod: '2026-06-29' },
-		{ path: '/contact', priority: '0.7', changefreq: 'monthly', lastmod: '2026-06-29' },
+		{ path: '/contact', priority: '0.7', changefreq: 'monthly', lastmod: '2026-02-08' },
 		{ path: '/blog', priority: '0.8', changefreq: 'weekly', lastmod: '2026-06-29' }
 	];
 

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
 			"headers": [
 				{
 					"key": "Cache-Control",
-					"value": "public, max-age=31536000, immutable"
+					"value": "public, max-age=3600"
 				}
 			]
 		},
@@ -14,7 +14,7 @@
 			"headers": [
 				{
 					"key": "Cache-Control",
-					"value": "public, max-age=31536000, immutable"
+					"value": "public, max-age=3600"
 				}
 			]
 		}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,24 @@
 {
+	"headers": [
+		{
+			"source": "/images/(.*)",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		},
+		{
+			"source": "/~partytown/(.*)",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		}
+	],
 	"rewrites": [
 		{
 			"source": "/proxytown/gtm",


### PR DESCRIPTION
## What changed
- Re-targeted homepage and equity administration service copy toward commercial SEO terms.
- Tightened careers page intent and delayed the job listing widget until the modal opens.
- Added four support articles for stock plan administration, Section 6039 reporting, equity compensation services, and choosing an equity management company.
- Simplified global Organization JSON-LD and stabilized sitemap `lastmod` values.
- Added static asset cache headers and delayed third-party Zoho/PageSense loading.
- Fixed invalid homepage service card markup and added ambient declarations needed for checks.

## Why
- Reduce buyer-intent keyword cannibalization from `/careers`.
- Give unranked/high-opportunity keywords dedicated supporting content.
- Improve crawler signals, schema clarity, and initial page load behavior.

## Verification
- `bun run check`
- `bun run build`

## Notes
- Excluded existing unrelated local formatting changes in `ContactForm.svelte`, `JobApplicationForm.svelte`, and `MeetTheTeam.svelte` from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several new blog articles covering equity compensation, stock plan administration, reporting, outsourcing, and vendor selection.
  * Updated the homepage and services content to better reflect equity management and stock plan administration offerings.
  * Added a refreshed Careers FAQ and improved job application flow.

* **Bug Fixes**
  * Fixed display issues in blog content and improved responsive hero image behavior.

* **Performance**
  * Improved loading behavior for third-party scripts and enabled long-term caching for static assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->