### PR TITLE
Constrain homepage brand mark height

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -341,12 +341,12 @@
 		</div>
 
 		<div
-			class="hidden w-[31vw] absolute bottom-0 right-[69vw] overflow-hidden opacity-50 md:block md:bottom-[10%] md:opacity-100"
+			class="absolute bottom-0 right-[69vw] hidden w-[31vw] overflow-hidden opacity-50 md:inset-y-[10%] md:block md:opacity-100"
 		>
 			<img
 				alt=""
 				aria-hidden="true"
-				class="max-w-none -translate-x-1/2 w-[50vw]"
+				class="h-full w-auto max-w-none -translate-x-1/2"
 				height="150"
 				loading="lazy"
 				src="/images/brand/aep-mark.svg"


### PR DESCRIPTION
## Summary

- constrain the decorative AEP brand mark to the homepage section height
- preserve the mark's aspect ratio and existing horizontal crop
- keep the intended 10% vertical inset at desktop breakpoints

## Root cause

The mark was sized with a viewport-width value. On wide viewports, its proportional height could exceed the section height and make the decoration appear outside its intended container.

## Impact

The brand mark now scales from the available section height and remains fully contained on wide screens without changing the mobile layout.

## Validation

- `bun run check`
- `bun run build`
- `bunx prettier --check src/routes/+page.svelte`
- visual containment checks at 2048×1068 and 1440×900


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive positioning of the decorative brand mark on medium and larger screens.
  * Updated the brand mark image to scale proportionally within its container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->