### PR TITLE
Make site copy more direct and specific

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -194,7 +194,7 @@
 										'@type': 'Service',
 										name: 'Comprehensive Equity Management',
 										description:
-											'Grant lifecycle administration and collaboration with internal teams for seamless execution.'
+											'Grant lifecycle administration coordinated with Payroll, HR, Accounting, Legal, and Treasury.'
 									}
 								},
 								{

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,24 +24,24 @@
 
 	const title = 'Equity Management Company & Compensation Consulting | Accelerated Equity Plans';
 	const description =
-		'A dedicated equity management company offering expert equity compensation consulting, stock plan administration, and tailored solutions to unlock the full potential of your equity programs.';
+		'Equity compensation consulting and stock plan administration for private and public companies, with support for systems, reporting, compliance, and transactions.';
 	const path = '/';
 
 	const servicesBoxes = [
 		{
 			icon: SquareChartGantt,
 			title: 'Why Equity Compensation Consulting Matters',
-			body: `<p>Navigating the world of equity compensation is complex. Companies face evolving regulations, the challenge of motivating and retaining key talent, and the need to balance shareholder and employee interests. Market volatility and rapid company growth only add to the complexity. At AEP, we understand these challenges and partner with you to build, manage, and optimize equity programs that drive engagement and business outcomes—while ensuring compliance every step of the way.</p>`
+			body: `<p>Equity compensation has to work for employees, shareholders, and the teams responsible for compliance. That gets harder as regulations change, markets move, and companies grow. AEP helps you build and run a program that supports the business without losing control of the details.</p>`
 		},
 		{
 			icon: FileChartPie,
 			title: 'Our Approach: Data-Driven, People-Focused',
-			body: '<p>We combine deep industry knowledge with technology and data analytics to deliver actionable insights for your equity programs. Our team leverages benchmarking, real-time reporting, and best-in-class platforms to give you clarity and confidence in your decision-making. Whether you’re evaluating plan effectiveness, preparing for an audit, or seeking to improve employee participation, we provide the tools and expertise to help you succeed.</p>'
+			body: '<p>We pair hands-on equity experience with benchmarking, reporting, and the systems your team already uses. The result is practical information you can use to assess a plan, prepare for an audit, or understand why employees are not participating.</p>'
 		},
 		{
 			icon: EarthIcon,
 			title: 'Who We Serve',
-			body: '<p>AEP supports organizations at every stage—from high-growth startups and pre-IPO companies to established public enterprises. We have deep experience across technology, biotech, financial services, and more. If you’re building, scaling, or optimizing an equity program, we’re ready to help.</p>'
+			body: '<p>AEP works with growing startups, pre-IPO companies, and established public companies. Our team has supported equity programs in technology, biotech, financial services, and other industries.</p>'
 		}
 	];
 
@@ -60,7 +60,7 @@
 			id: 'equity-plan-administration',
 			title: 'Equity Plan Administration',
 			detailsLink: '/services/equity-plan-administration',
-			body: '<p>Our specialized services in stock plan administration are crafted to address the unique needs of businesses seeking to streamline their equity management processes. Our team of dedicated professionals delivers tailored solutions that ensure regulatory compliance and seamless management of employee stock compensation programs. Trust AEP to handle the complexities of your stock plan administration, allowing you to focus on your core business objectives. </p>',
+			body: '<p>We run the recurring work behind your stock plan, including grants, releases, reporting, compliance, and employee support. We can own the full program or add experienced help where your internal team needs it.</p>',
 			tags: [
 				'Outsourced administration',
 				'Seasonal & temporary support',
@@ -75,7 +75,7 @@
 			id: 'vendor-support',
 			title: 'Vendor Support',
 			detailsLink: '/services/vendor-support',
-			body: "<p>Maximize the potential of your equity system with AEP's expert vendor support. Whether you aim to optimize your current equity administration platform or seek to find and implement a new one, AEP is here to help. We specialize in all vendor platforms and will guide you through finding, implementing, and optimizing the platform that best suits your needs.</p>",
+			body: '<p>We help you choose, implement, and improve equity administration platforms. Our team works across major vendors, so the recommendation starts with your requirements rather than a preferred system.</p>',
 			tags: [
 				'Expedited system implementation',
 				'Data conversion and audit',
@@ -90,7 +90,7 @@
 			id: 'advanced-project-support',
 			title: 'Advanced Project Support',
 			detailsLink: '/services/advanced-project-support',
-			body: '<p>AEP offers a comprehensive suite of services designed to empower businesses across various industries and lifecycles. Our focus on quality, integrity, and client satisfaction ensures that we partner effectively with businesses to navigate challenges, optimize operations, and unlock opportunities for long-term success.</p>',
+			body: '<p>IPOs, acquisitions, corporate actions, and global expansion create more equity work than many internal teams can absorb. AEP provides experienced project support for the analysis, coordination, testing, and communication these events require.</p>',
 			tags: [
 				'Mergers & Acquisitions',
 				'IPOs & SPACs',
@@ -106,7 +106,7 @@
 			id: 'plan-process-design',
 			title: 'Plan & Process Design',
 			detailsLink: '/services/plan-process-design',
-			body: '<p>AEP assists both private and public companies in their stock plan administration by providing expert guidance and comprehensive solutions. From the initial design and implementation of your equity plans to ongoing management and compliance, AEP has you covered.</p>',
+			body: '<p>We review how your equity program works today, document the gaps, and design processes your team can maintain. Our consultants also train administrators and help put the right controls in place.</p>',
 			tags: [
 				'Process review, enhancement, and documentation',
 				'Incorporation of best practices to mitigate risk',
@@ -329,9 +329,9 @@
 				<div class="prose max-w-none">
 					<p class="text-lg font-light text-zinc-600 max-w-[56ch] text-pretty">
 						As a dedicated equity management company, Accelerated Equity Plans partners with you to
-						boost your team's effectiveness in equity compensation. We handle plan adjustments,
-						daily operations, and future strategy, allowing you to focus on leading your company
-						forward.
+						take work off your internal team without taking them out of the process. We handle plan
+						adjustments, daily administration, and longer-term planning so they can focus on the
+						decisions that need their attention.
 					</p>
 				</div>
 				<div class="flex gap-x-4">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -9,7 +9,7 @@
 
 	const title = 'About Accelerated Equity Plans | Equity Compensation Experts';
 	const description =
-		'Learn how Accelerated Equity Plans empowers companies with expert equity compensation solutions. Discover our story, principles, and leadership team dedicated to maximizing the impact of your stock plans.';
+		'Learn about Accelerated Equity Plans, our approach to equity compensation consulting, and the experienced team that supports our clients.';
 	const path = '/about';
 </script>
 
@@ -49,11 +49,9 @@
 				/>
 				<h1 class={styles.h1}>About Accelerated Equity Plans</h1>
 				<p class="mx-auto mt-6 max-w-3xl text-lg font-light leading-8">
-					We empower companies to harness the full potential of equity compensation with strategic
-					solutions to attract, retain, and motivate top talent. Our comprehensive services ensure
-					equity plans are effectively managed and aligned with business goals, creating a
-					competitive advantage. Leverage our expertise to maximize the impact of your equity
-					programs and foster a motivated, loyal workforce driving your company’s success.
+					We help companies design and run equity programs that employees can understand and
+					internal teams can manage. Our work covers daily administration, systems, compliance, and
+					the projects that come with growth or a major transaction.
 				</p>
 			</div>
 		</div>
@@ -69,21 +67,20 @@
 		<div class="mt-8 max-w-full font-medium prose prose-lg">
 			<p>
 				<span class="text-red-700">Our Founding.</span> Founded in 2021 by industry experts determined
-				to share their wealth of knowledge and provide unparalleled support to the field, Accelerated
-				Equity stands as a beacon of expertise and dedication.
+				to share their experience and give companies a more responsive option for equity support, Accelerated
+				Equity Plans has grown into a team of seasoned administrators and consultants.
 			</p>
 			<p>
-				<span class="text-red-700">Our Principles.</span> At Accelerated Equity, we transcend mere execution
-				of equity plans; we prioritize empowering our clients with a deep understanding of the underlying
-				principles driving their strategies. Leveraging the collective expertise of our seasoned team,
-				we forge strong partnerships within the industry to deliver a truly exceptional experience.
+				<span class="text-red-700">Our Principles.</span> We do more than process transactions. We explain
+				the reasoning behind the work, document what matters, and make sure clients understand the program
+				they are responsible for. We also work closely with the legal, tax, accounting, payroll, and platform
+				partners involved in each plan.
 			</p>
 			<p>
-				<span class="text-red-700">Our Track Record.</span> Our success is evident: from guiding private
-				and pre-IPO ventures to supporting some of the world's largest multinational corporations, our
-				commitment to excellence knows no bounds. At AEP, we are dedicated to empowering our clients with
-				the tools and understanding necessary to navigate the complexities of equity planning with confidence
-				and clarity.
+				<span class="text-red-700">Our Track Record.</span> We have supported private and pre-IPO companies
+				as well as large multinational public companies. That range gives our clients access to people
+				who have seen how equity programs change as a company grows, adds new award types, or enters new
+				markets.
 			</p>
 		</div>
 	</section>
@@ -100,9 +97,8 @@
 			</div>
 			<div class="font-light prose">
 				<p>
-					Send us an email or give us a call to discover how our experts can assist you. Our team is
-					ready to provide personalized solutions and support to elevate your stock plan and meet
-					your business needs. Contact us today to get started!
+					Tell us what is working, what is not, and where your team needs help. We will talk through
+					the problem and recommend the right level of support for your stock plan.
 				</p>
 			</div>
 			<div class="flex gap-x-4">

--- a/src/routes/careers/+page.svelte
+++ b/src/routes/careers/+page.svelte
@@ -28,22 +28,22 @@
 		{
 			icon: People,
 			title: 'Community',
-			body: "<p>At AEP, we're more than just a workplace; we're a community of passionate individuals united by a shared commitment to a culture of ownership, continuous learning, and fostering an environment where growth and fun go hand in hand.</p>"
+			body: '<p>People at AEP take ownership of their work, share what they know, and make time to help one another. We take the work seriously without making the workplace stiff.</p>'
 		},
 		{
 			icon: Key,
 			title: 'Employee Ownership',
-			body: "<p>If you're someone who believes in the transformative power of employee ownership and thrives in an environment that values collaboration, innovation, and personal development, then we want to hear from you.</p>"
+			body: '<p>We believe employee ownership works best when people understand it. That belief shapes both our client work and the way we run AEP.</p>'
 		},
 		{
 			icon: Growth,
 			title: 'Growth',
-			body: "<p>We're seeking dedicated professionals to join our team. Whether you're an industry veteran or just starting your career, AEP offers exciting opportunities for growth, advancement, and making a meaningful impact.</p>"
+			body: "<p>Whether you already know equity compensation or are building your career in the field, you'll have room to take on harder work and learn from experienced consultants.</p>"
 		},
 		{
 			icon: LightningBolt,
 			title: 'Dynamic Team',
-			body: '<p>Join our dynamic team to make a meaningful impact, grow your skills, and have fun. At AEP, we value your unique talents and offer a supportive environment for career advancement.</p>'
+			body: '<p>Our team brings different backgrounds and specialties to the work. You will collaborate closely with colleagues while building expertise of your own.</p>'
 		}
 	];
 

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -12,7 +12,7 @@
 
 	const title = 'Contact Accelerated Equity Plans | Expert Equity Consulting & Support';
 	const description =
-		'Get in touch with Accelerated Equity Plans for personalized equity plan consulting, system support, and expert guidance. Call, email, or fill out our contact form to start your equity management journey today.';
+		'Contact Accelerated Equity Plans about equity plan administration, consulting, system support, or a specific project.';
 	const path = '/contact';
 </script>
 
@@ -45,10 +45,8 @@
 				<h1 class={styles.h1}>Contact Us Today</h1>
 				<div class="max-w-full prose">
 					<p class="mx-auto mt-6 max-w-3xl text-lg font-light leading-8 text-white">
-						Gain peace of mind with our expert team dedicated to supporting your success. Whether
-						you need help with equity planning, system implementation, or ongoing support, we're
-						here to provide personalized solutions and guidance, helping you navigate with
-						confidence.
+						Tell us where your equity program needs support. We can help with plan administration,
+						system implementation, process design, or a specific project.
 					</p>
 				</div>
 			</div>
@@ -138,10 +136,8 @@
 					<div class="p-8 text-white bg-black rounded-xl">
 						<h3 class={styles.h4}>Contact Us</h3>
 						<p class="mt-4 font-light">
-							Ready to take the next step? Fill out the form below and let us know how we can help.
-							Whether you have questions, need expert advice, or just want to chat about your
-							business goals, our team is here to support you every step of the way. We look forward
-							to connecting!
+							Use the form below to describe your equity program and the help you need. We will
+							review your note and follow up to discuss the scope, timing, and next steps.
 						</p>
 						<ContactForm />
 					</div>
@@ -239,8 +235,7 @@
 					<p class="text-3xl font-bold font-headings text-red-700">100%</p>
 					<p class="mt-2 text-stone-700 font-medium">U.S.-Based Team</p>
 					<p class="mt-1 text-sm text-stone-500">
-						Every team member is based in the United States, ensuring seamless communication and
-						compliance expertise.
+						Every team member is based in the United States and works directly with client teams.
 					</p>
 				</div>
 			</div>

--- a/src/routes/services/+page.svelte
+++ b/src/routes/services/+page.svelte
@@ -31,7 +31,7 @@
 
 	const title = 'Equity Plan Administration & Consulting Services | Accelerated Equity Plans';
 	const description =
-		'Discover comprehensive equity plan administration, vendor support, project consulting, and process design services with Accelerated Equity Plans. Get expert help with stock plans, M&A, IPOs, automation, and more; tailored for private and public companies.';
+		'Equity plan administration, vendor support, project consulting, and process design for private and public companies.';
 	const path = '/services';
 
 	const servicesSections = [
@@ -39,7 +39,7 @@
 			icon: Money,
 			id: 'equity-plan-administration',
 			title: 'Equity Plan Administration',
-			body: '<p>Our specialized services in stock plan administration are crafted to address the unique needs of businesses seeking to streamline their equity management processes. Our team of dedicated professionals delivers tailored solutions that ensure regulatory compliance and seamless management of employee stock compensation programs. Trust AEP to handle the complexities of your stock plan administration, allowing you to focus on your core business objectives.</p>',
+			body: '<p>We handle the recurring work behind your stock plan, including grants, releases, reporting, compliance, and employee support. AEP can run the full program or work alongside your internal team on selected responsibilities.</p>',
 			servicesBackgroundColor: 'bg-red-700',
 			detailsLink: '/services/equity-plan-administration',
 			services: [
@@ -69,7 +69,7 @@
 			icon: Buildings,
 			id: 'vendor-support',
 			title: 'Vendor Support',
-			body: "<p>Maximize the potential of your equity system with AEP's expert vendor support. Whether you aim to optimize your current equity administration platform or seek to find and implement a new one, AEP is here to help. We specialize in all vendor platforms and will guide you through finding, implementing, and optimizing the platform that best suits your needs.</p>",
+			body: '<p>We help companies choose, implement, migrate, test, and improve equity administration platforms. Because we work across major vendors, we can focus on the system and configuration that fit your requirements.</p>',
 			servicesBackgroundColor: 'bg-aep-teal',
 			detailsLink: '/services/vendor-support',
 			services: [
@@ -99,7 +99,7 @@
 			icon: GridCheck,
 			id: 'advanced-project-support',
 			title: 'Advanced Project Support',
-			body: '<p>AEP offers a comprehensive suite of services designed to empower businesses across various industries and lifecycles. Our focus on quality, integrity, and client satisfaction ensures that we partner effectively with businesses to navigate challenges, optimize operations, and unlock opportunities for long-term success.</p>',
+			body: '<p>IPOs, acquisitions, corporate actions, and global expansion can create a sharp increase in equity work. We provide experienced project support for the analysis, coordination, testing, and communication required to get through those events.</p>',
 			servicesBackgroundColor: 'bg-black',
 			detailsLink: '/services/advanced-project-support',
 			services: [
@@ -116,7 +116,7 @@
 				{
 					icon: Trailer,
 					title: 'Global Workforce Mobility Support',
-					body: '<p>We offer comprehensive support for mobility adoption, ensuring a seamless experience for your relocating employees.</p>'
+					body: '<p>We help track mobile employees and grants, coordinate with tax advisors, and explain how a move affects each participant’s awards.</p>'
 				},
 				{
 					icon: GridBlock,
@@ -129,7 +129,7 @@
 			icon: Compass,
 			id: 'plan-process-design',
 			title: 'Plan & Process Design',
-			body: '<p>AEP assists both private and public companies in their stock plan administration by providing expert guidance and comprehensive solutions. From the initial design and implementation of your equity plans to ongoing management and compliance, AEP has you covered.</p>',
+			body: '<p>We review how an equity program operates, document the gaps, and design processes the team can maintain. Our consultants also train administrators and help put practical controls in place.</p>',
 			servicesBackgroundColor: 'bg-aep-teal-dark',
 			detailsLink: '/services/plan-process-design',
 			services: [
@@ -171,7 +171,7 @@
 		{
 			id: 'automation-design-and-resources',
 			title: `Automation Design and Resources`,
-			body: `Our Automation Design and Resources empower organizations to streamline processes and boost productivity. We integrate your equity systems with payroll and HRIS for seamless data flow and reduced risk, driving both efficiency and innovation.`
+			body: `We automate repetitive equity tasks and connect equity systems with payroll and HRIS. This reduces manual entry, gives teams consistent data, and adds controls around each transfer.`
 		},
 		{
 			id: 'tax-and-mobility-implementation-and-support',

--- a/src/routes/services/advanced-project-support/+page.svelte
+++ b/src/routes/services/advanced-project-support/+page.svelte
@@ -15,7 +15,7 @@
 
 	const title = 'Advanced Equity Project Support & Consulting | Accelerated Equity Plans';
 	const description =
-		'Expert support for complex equity projects including M&A, IPOs, SPACs, plan modifications, automation, global mobility, and system integrations. Navigate critical transitions with confidence.';
+		'Project support for M&A, IPOs, SPACs, plan modifications, automation, global mobility, and equity system integrations.';
 	const path = '/services/advanced-project-support';
 
 	const features = [
@@ -23,25 +23,25 @@
 			icon: Events,
 			title: 'Strategic Transactions & Equity Events',
 			description:
-				'Navigate the complexities of Mergers & Acquisitions, IPOs, SPACs, and other strategic transactions with expert guidance. We manage equity treatment analysis, participant communications, system conversions, and regulatory compliance to ensure smooth execution of even the most complex corporate events.'
+				'We support equity treatment analysis, participant communications, system conversions, and compliance work for M&A, IPOs, SPACs, and other corporate events. Our consultants coordinate the details across internal teams and external advisors.'
 		},
 		{
 			icon: Path,
 			title: 'Equity Plan Modifications & Automation',
 			description:
-				'Transform your equity operations through strategic plan modifications and intelligent automation. We help you design process improvements, implement workflow automation, eliminate manual tasks, and leverage technology to increase efficiency while reducing risk and operational costs.'
+				'We redesign plan workflows and automate repetitive steps where the process and controls are clear. The goal is less manual entry, fewer handoffs, and a record your team can review.'
 		},
 		{
 			icon: Trailer,
 			title: 'Global Workforce Mobility Support',
 			description:
-				'Support your global workforce with comprehensive mobility solutions. We provide expert guidance on international equity compensation, tax compliance across jurisdictions, mobility grant tracking, and participant education to ensure seamless experiences for relocating employees.'
+				'We help track mobile employees and grants, coordinate tax requirements across jurisdictions, and explain the equity impact to participants. Our team works with your tax and legal advisors on country-specific requirements.'
 		},
 		{
 			icon: GridBlock,
 			title: 'Seamless System Integrations',
 			description:
-				'Create a unified technology ecosystem by integrating your equity platform with HRIS, payroll, and other enterprise systems. We design automated data flows that eliminate manual reconciliation, reduce errors, ensure data consistency, and provide real-time visibility across your technology stack.'
+				'We connect the equity platform with HRIS, payroll, and other business systems. Each integration includes data mapping, validation rules, error handling, and a reconciliation process.'
 		}
 	];
 
@@ -49,12 +49,12 @@
 		{
 			title: 'IPO Preparation & Execution',
 			description:
-				'Transform your private company equity program for public markets. We handle Section 16 setup, insider trading policy development, Form S-8 preparation, transition from private to public grant types, participant education, and all operational changes required for your public debut.'
+				'We prepare private-company equity operations for public-company requirements, including Section 16 setup, insider trading policies, Form S-8 preparation, award transitions, and participant education.'
 		},
 		{
 			title: 'Merger & Acquisition Support',
 			description:
-				"Navigate equity complexities in M&A transactions. Our services include equity compensation due diligence, treatment analysis, participant communications, system consolidations, regulatory compliance, and post-merger integration to ensure equity compensation doesn't become a deal impediment."
+				'We support equity due diligence, award treatment analysis, participant communications, system consolidation, compliance, and post-close integration. This gives the deal team a clear view of equity obligations before and after closing.'
 		},
 		{
 			title: 'SPAC Transactions',
@@ -64,12 +64,12 @@
 		{
 			title: 'Corporate Restructuring',
 			description:
-				'Execute complex equity adjustments for spinoffs, stock splits, reverse splits, and other corporate restructuring events. We ensure accurate adjustments, clear participant communications, and seamless system updates while maintaining compliance and audit trails.'
+				'We calculate and process equity adjustments for spinoffs, stock splits, reverse splits, and other restructurings. The work includes participant communications, system updates, reconciliation, and audit support.'
 		},
 		{
 			title: 'Global Expansion',
 			description:
-				'Extend your equity program internationally with confidence. We help you navigate local regulations, establish compliant grant structures, implement tax-efficient approaches, and educate international participants about their awards.'
+				'We help companies extend equity programs into new countries, coordinating local rules, grant structures, tax considerations, and participant education with the appropriate advisors.'
 		},
 		{
 			title: 'System Modernization',
@@ -110,7 +110,7 @@
 		{
 			question: 'What M&A equity support do you provide?',
 			answer:
-				"<p>M&A transactions create complex equity scenarios requiring quick decisions and flawless execution. We provide equity compensation due diligence, equity treatment analysis (acceleration, conversion, cash-out scenarios), integration planning, participant communications, data consolidation, system migrations, regulatory compliance support, and post-merger administration. Whether you're the acquirer or target, our experience helps you avoid common pitfalls and ensure equity doesn't impede deal closure.</p>"
+				"<p>M&A transactions create equity questions that need quick, well-documented decisions. We support due diligence, award treatment analysis, integration planning, participant communications, data consolidation, system migrations, compliance, and post-merger administration. Whether you're the acquirer or target, we help identify equity obligations before they delay the deal.</p>"
 		},
 		{
 			question: 'Do you perform equity compensation due diligence?',
@@ -211,8 +211,8 @@
 				<h1 class={clsx(styles.h1, 'text-white')}>Advanced Equity Project Support Services</h1>
 			</div>
 			<p class="mx-auto max-w-3xl text-lg font-light text-white">
-				Navigate complex equity projects with confidence. From IPOs and M&A to automation and global
-				expansion, we provide the specialized expertise you need for success.
+				Bring in experienced help for the equity work behind IPOs, M&A, automation, and global
+				expansion.
 			</p>
 		</div>
 	</section>
@@ -231,25 +231,20 @@
 				<h2 class={styles.h2}>Expert Support for Complex Equity Initiatives</h2>
 				<div class="prose max-w-4xl text-lg text-stone-700 font-light">
 					<p>
-						Major equity projects—whether an IPO, M&A transaction, global expansion, or a
-						<a href={resolve('/services/vendor-support')}>technology platform transformation</a
-						>—represent critical moments for your organization. Success requires specialized
-						expertise, careful planning, and flawless execution. Mistakes can be costly, both
-						financially and reputationally.
+						Major equity projects, including an IPO, M&A transaction, global expansion, or a
+						<a href={resolve('/services/vendor-support')}>technology platform transformation</a>,
+						put extra pressure on equity teams. They require specialized knowledge, careful
+						planning, and accurate execution. Mistakes can be costly and difficult to unwind.
 					</p>
 					<p>
-						AEP brings deep, specialized knowledge gained from managing hundreds of complex equity
-						projects across industries. We understand the technical requirements, regulatory
-						complexities, and operational challenges that come with high-stakes equity initiatives.
-						More importantly, we know how to navigate these successfully while managing risk and
-						meeting tight deadlines.
+						AEP has managed hundreds of complex equity projects across industries. We understand the
+						technical requirements, regulatory constraints, and operational work behind these
+						events, including the dependencies that can threaten a deadline.
 					</p>
 					<p>
-						Our approach combines proven methodologies with the flexibility to adapt to your unique
-						circumstances. We integrate seamlessly with your team, providing the specialized
-						expertise and additional bandwidth you need precisely when you need it. Whether you
-						require comprehensive project management or targeted support for specific work streams,
-						we deliver results that enable your business objectives.
+						We work inside your existing project structure or manage the equity workstream directly.
+						The scope can cover the full project or a defined set of tasks where the internal team
+						needs more capacity.
 					</p>
 				</div>
 			</div>

--- a/src/routes/services/equity-plan-administration/+page.svelte
+++ b/src/routes/services/equity-plan-administration/+page.svelte
@@ -24,25 +24,25 @@
 			icon: Bank,
 			title: 'Comprehensive Equity Management',
 			description:
-				'End-to-end management of your equity compensation program, from initial grant issuance through vesting, exercise, and settlement. We handle all aspects of the grant lifecycle while collaborating seamlessly with your Payroll, HR, Accounting, Legal, and Treasury teams to ensure smooth execution and regulatory compliance.'
+				'We manage the grant lifecycle from issuance through vesting, exercise, and settlement. Our administrators coordinate directly with Payroll, HR, Accounting, Legal, and Treasury so transactions are processed correctly and on time.'
 		},
 		{
 			icon: Education,
 			title: 'Employee Education & Onboarding',
 			description:
-				'Empower your employees with clear, accessible education about their equity compensation. We provide comprehensive resources, personalized onboarding sessions, and ongoing support to help employees understand the value of their equity awards and make informed decisions throughout their equity journey.'
+				'We give employees clear materials, onboarding sessions, and a place to bring their questions. They learn what they have been granted, how it works, and where to find the information they need.'
 		},
 		{
 			icon: People,
 			title: 'Outsourced Administration & Scalable Support',
 			description:
-				'Let us take complete ownership of your equity plan administration. Our team provides ongoing, day-to-day management of your program with flexible staffing solutions that scale with your needs. Whether you need full outsourcing or targeted support for specific functions, we adapt to your workload and business requirements.'
+				'Our team can own day-to-day administration or take responsibility for selected workflows. You can increase or reduce support as transaction volume, deadlines, and internal capacity change.'
 		},
 		{
 			icon: Graph,
 			title: 'Interim, Fractional & On-Demand Support',
 			description:
-				'Navigate peak periods with confidence. Whether you need an interim stock plan administrator to cover a vacancy, a fractional administrator for part-time ongoing coverage, or on-demand stock administration during annual grant cycles, year-end reporting, or M&A transactions, we provide experienced equity professionals exactly when you need them—without long-term commitments.'
+				'Bring in an interim administrator for a vacancy, a fractional administrator for ongoing part-time coverage, or short-term help for annual grants, year-end reporting, and M&A. You get an experienced equity professional for the period you need.'
 		}
 	];
 
@@ -50,22 +50,22 @@
 		{
 			title: 'Regulatory Compliance Expertise',
 			description:
-				'Stay ahead of complex regulatory requirements with our deep knowledge of SEC rules, tax regulations, and accounting standards. We ensure your equity program maintains full compliance with all applicable regulations, reducing risk and protecting your organization.'
+				'Our team works with SEC reporting, tax rules, accounting standards, and plan requirements every day. We build the required checks and deadlines into the administration process to reduce missed filings and avoidable errors.'
 		},
 		{
 			title: 'Process Efficiency & Automation',
 			description:
-				'Streamline your equity administration with optimized workflows and automated processes. We identify opportunities to reduce manual work, minimize errors, and free your team to focus on strategic initiatives rather than administrative tasks.'
+				'We find repetitive work, unnecessary handoffs, and places where errors enter the process. Then we simplify or automate those steps so your team spends less time correcting data and moving files.'
 		},
 		{
 			title: 'Vendor Platform Expertise',
 			description:
-				"Maximize the value of your equity management platform. Our team has extensive experience with all major vendor systems and can help you leverage advanced features, optimize configurations, and ensure you're getting the most from your technology investment."
+				'Our team works across major equity platforms. We can correct configurations, introduce useful features, and remove workarounds that no longer make sense.'
 		},
 		{
 			title: 'Flexible Engagement Models',
 			description:
-				'Choose the support model that fits your needs—from full outsourcing to targeted project assistance or temporary staffing. Our flexible engagement options let you access precisely the expertise you need, when you need it, without over-committing resources.'
+				'Choose full outsourcing, support for a defined set of tasks, or temporary staffing. The engagement can change when your workload or internal team changes.'
 		}
 	];
 
@@ -108,7 +108,7 @@
 		{
 			question: 'Can you provide an interim or fractional stock plan administrator?',
 			answer:
-				'<p>Yes. We offer interim stock plan administrators to cover a vacancy or leave of absence, fractional administrators who manage your program on a part-time, ongoing basis, and on-demand stock administration for short-term, project-based needs. This flexibility lets you maintain seamless administration and compliance without the cost or commitment of a full-time hire.</p>'
+				'<p>Yes. We offer interim stock plan administrators to cover a vacancy or leave of absence, fractional administrators who manage your program on a part-time, ongoing basis, and on-demand stock administration for short-term, project-based needs. This keeps required administration and compliance work moving without the cost or commitment of a full-time hire.</p>'
 		},
 		{
 			question: 'What makes your equity administration services different?',

--- a/src/routes/services/plan-process-design/+page.svelte
+++ b/src/routes/services/plan-process-design/+page.svelte
@@ -23,25 +23,25 @@
 			icon: FolderEdit,
 			title: 'Streamlined & Optimized Equity Management',
 			description:
-				'Transform your equity program through comprehensive review and optimization. We analyze your current processes, identify inefficiencies and risks, document workflows, and implement best practices that enhance efficiency while minimizing compliance risk. The result is a streamlined program that runs smoothly and supports your business objectives.'
+				'We review how your equity program operates, identify weak controls and wasted effort, and document the workflows that need to change. Then we help put the new process into daily use.'
 		},
 		{
 			icon: Presentation,
 			title: 'Expert Administrator Training & Support',
 			description:
-				'Empower your team with the knowledge and skills they need for success. We provide comprehensive training on equity administration fundamentals, platform-specific system training, process documentation, and ongoing coaching. Your administrators gain confidence and competence to manage your program effectively.'
+				'We train administrators on equity fundamentals, the company’s platform, and its own procedures. Training can include working sessions, reference materials, and follow-up coaching.'
 		},
 		{
 			icon: Stars,
 			title: 'Data-Driven Decision Making',
 			description:
-				'Make informed decisions about your equity compensation strategy with industry intelligence and competitive insights. We provide ongoing trend analysis, peer benchmarking, regulatory updates, and strategic recommendations to keep your Long-Term Incentive plans competitive and effective.'
+				'We use peer benchmarks, market trends, and regulatory updates to inform Long-Term Incentive plan decisions. Recommendations connect that data to the company’s talent goals and operating constraints.'
 		},
 		{
 			icon: Umbrella,
 			title: 'Risk Mitigation Through Best Practices',
 			description:
-				'Protect your organization by incorporating proven best practices into your equity program. We help you establish strong controls, implement proper governance, ensure regulatory compliance, and create audit trails that stand up to scrutiny. Reduce risk while maintaining operational efficiency.'
+				'We help establish approval workflows, ownership, compliance checks, and audit records. These controls reduce risk without adding review steps that the team cannot maintain.'
 		}
 	];
 
@@ -54,7 +54,7 @@
 		{
 			title: 'Process Assessment & Optimization',
 			description:
-				'Comprehensive review of your current equity administration processes to identify improvement opportunities. We document workflows, highlight inefficiencies, recommend optimizations, and help you implement streamlined processes that reduce manual work and risk.'
+				'We document current equity administration workflows, identify weak points, and help implement changes that reduce manual work and risk.'
 		},
 		{
 			title: 'Governance & Controls',
@@ -64,7 +64,7 @@
 		{
 			title: 'Compliance Program Development',
 			description:
-				'Build comprehensive compliance programs tailored to your requirements. Whether you need Section 16 programs for public companies, insider trading policies, 409A compliance for private companies, or international regulatory compliance, we provide expert guidance and implementation support.'
+				'We help build Section 16 programs, insider trading policies, private-company 409A processes, and international compliance workflows around the company’s actual requirements.'
 		},
 		{
 			title: 'Plan Document Services',
@@ -74,7 +74,7 @@
 		{
 			title: 'Change Management',
 			description:
-				'Successfully navigate changes to your equity program through structured change management. We help you communicate changes effectively, train stakeholders, manage resistance, and ensure smooth adoption of new processes, systems, or plan designs.'
+				'When a process, system, or plan changes, we prepare communications, train the affected teams, and track whether the new way of working has taken hold.'
 		}
 	];
 
@@ -236,8 +236,8 @@
 						At AEP, we help both private and public companies design equity programs that align with
 						business objectives, attract and retain talent, and operate efficiently. Our consulting
 						approach combines strategic thinking with operational practicality. We don't just
-						recommend what sounds good in theory—we design solutions that actually work in your
-						environment with your constraints.
+						recommend what sounds good in theory. We design solutions that work in your environment
+						with your constraints.
 					</p>
 					<p>
 						Our team brings deep expertise in equity plan design, regulatory compliance, operational
@@ -342,8 +342,8 @@
 					<h3 class={clsx(styles.h3)}>3. Design Optimal Solutions</h3>
 					<p class="font-light text-white/90">
 						We develop recommendations grounded in best practices but tailored to your specific
-						needs. Our designs balance competing objectives—effectiveness vs. simplicity, automation
-						vs. control, flexibility vs. governance—to create practical solutions.
+						needs. Our designs account for competing objectives such as effectiveness and
+						simplicity, automation and control, or flexibility and governance.
 					</p>
 				</div>
 

--- a/src/routes/services/vendor-support/+page.svelte
+++ b/src/routes/services/vendor-support/+page.svelte
@@ -23,25 +23,25 @@
 			icon: Nodes,
 			title: 'Streamlined System Implementation',
 			description:
-				'Navigate the complexities of equity system implementation with confidence. We expedite the setup process, manage project timelines, coordinate with vendors, and ensure a smooth transition to your new platform. Our structured approach minimizes disruption while rapidly delivering functionality to your team.'
+				'We plan the implementation, coordinate with the vendor, and keep decisions and deadlines moving. Before launch, we confirm that the new platform supports the workflows your team depends on.'
 		},
 		{
 			icon: Database,
 			title: 'Data Management & Integration',
 			description:
-				'Transform your equity data with precision and care. We handle complete data conversion from spreadsheets or legacy systems, conduct thorough data audits to ensure accuracy, and integrate with your HRIS, payroll, and other third-party systems. Our rigorous quality control processes guarantee your data integrity throughout the migration.'
+				'We convert data from spreadsheets or legacy systems, audit it against the source, and connect the new platform with HRIS, payroll, and other systems. Reconciliation and documented review points protect the data throughout the move.'
 		},
 		{
 			icon: DocumentCheck,
 			title: 'RFP Guidance & System Selection',
 			description:
-				'Make informed decisions about your equity technology investment. We guide you through the entire RFP process, from defining requirements and evaluating vendors to negotiating contracts. Our vendor-agnostic approach ensures you select the platform that truly fits your needs, not just the one with the best sales pitch.'
+				'We help define requirements, prepare the RFP, evaluate demonstrations, compare vendors, and support contract discussions. Because we work across platforms, we can assess each option against the way your program actually operates.'
 		},
 		{
 			icon: TestTube,
 			title: 'Comprehensive Functionality Testing',
 			description:
-				'Ensure your equity system performs flawlessly before going live. We conduct thorough testing of all critical functionality including grant processing, vesting schedules, tax calculations, reporting, and integrations. Our detailed test plans and quality assurance processes identify and resolve issues before they impact your operations.'
+				'Before go-live, we test grant processing, vesting schedules, tax calculations, reporting, and integrations. Detailed test cases make failures visible while there is still time to correct them.'
 		}
 	];
 
@@ -65,7 +65,7 @@
 		{
 			title: 'Shareworks Administration Support',
 			description:
-				'We provide expert Shareworks (Morgan Stanley at Work) administration support, including implementation, data migration, participant management, reporting, and ongoing optimization. Our team helps you unlock the platform’s advanced capabilities and keep your equity program running smoothly.'
+				'We support Shareworks implementation, data migration, participant management, reporting, and ongoing administration. We can also review the current setup and introduce platform features that replace manual work.'
 		},
 		{
 			title: 'Fidelity Stock Plan Services Support',
@@ -83,22 +83,22 @@
 		{
 			title: 'Maximize Platform Value',
 			description:
-				"Most companies utilize only a fraction of their equity platform's capabilities. Our team helps you unlock advanced features, automate manual processes, and optimize configurations to get the maximum return on your technology investment."
+				'Many companies use only the basic features of their equity platform. We review the configuration, identify useful features that are not in use, and automate work the system can already handle.'
 		},
 		{
 			title: 'Reduce Implementation Risk',
 			description:
-				'System implementations often face delays, budget overruns, and functionality gaps. Our proven methodology and hands-on project management dramatically reduce these risks, ensuring on-time delivery and complete functionality.'
+				'Implementations slip when requirements, ownership, or testing are unclear. We make those decisions explicit, track open items, and test critical workflows before the launch date.'
 		},
 		{
 			title: 'Vendor-Agnostic Expertise',
 			description:
-				'Unlike vendor professional services teams focused on a single platform, we bring cross-platform expertise. This broader perspective helps you implement best practices regardless of your chosen vendor and ensures objective guidance on system selection.'
+				'Our consultants work across major equity platforms. That experience helps us compare vendors and recommend configurations based on your requirements instead of one system’s default approach.'
 		},
 		{
 			title: 'Seamless Data Migration',
 			description:
-				'Data migration is often the riskiest part of any system change. Our meticulous approach to data conversion, validation, and reconciliation ensures 100% accuracy while maintaining full audit trails and compliance documentation.'
+				'We map, convert, validate, and reconcile migrated data against the source system. The project retains the review history and supporting documentation needed for later audits.'
 		}
 	];
 
@@ -306,8 +306,8 @@
 				<h2 class={styles.h2}>Platform-Specific Support</h2>
 				<p class="prose max-w-4xl text-lg text-stone-700 font-light">
 					Need help with a specific equity platform? Our administrators work in these systems every
-					day. Below are a few of the platforms we support most often—each engagement is tailored to
-					your configuration, data, and team.
+					day. These are a few of the platforms we support most often. The work depends on your
+					configuration, data, and team.
 				</p>
 			</div>
 


### PR DESCRIPTION
## Summary

- replace generic promotional language with concrete descriptions of AEP services
- tighten homepage, company, careers, contact, and service-page copy
- preserve existing page and card titles

## Validation

- `bun run check`
- `bun run lint`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refreshed marketing copy and metadata across the homepage, About, Careers, Contact, and Services pages.
  * Clarified offerings for equity administration, consulting, vendor support, process design, project support, and systems expertise.
  * Improved descriptions of operational support, compliance, reporting, platform selection, implementation, and process optimization.
  * Updated service-page FAQs, introductions, benefits, and feature descriptions with more concise, outcome-focused language.
  * Refined structured-data messaging to highlight coordination across key business functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->